### PR TITLE
[DO NOT MERGE] amd64 AVX2 dot8 bundle — bench + correctness

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,0 +1,105 @@
+name: Bench
+
+# On-demand throughput benchmark used to drive the amd64 SIMD work: it reports
+# token-generation (tg) and prompt-processing (pp) tok/s for a Q8_0 model on a
+# real amd64 runner and on a native arm64 runner, so the two can be compared,
+# and prints each runner's CPU SIMD capabilities. Trigger with:
+#   gh workflow run bench.yml -f llamawasm2go_ref=<branch-or-version>
+# It also runs automatically on every push to a perf/** branch, benchmarking
+# whatever llamawasm2go the branch's go.mod pins — that is the amd64 dev loop.
+on:
+  push:
+    branches: ["perf/**"]
+  workflow_dispatch:
+    inputs:
+      llamawasm2go_ref:
+        description: "llamawasm2go module version or branch to benchmark (blank = go.mod pin)"
+        required: false
+        default: ""
+      decode_tokens:
+        description: "tokens to decode for the tg benchmark"
+        required: false
+        default: "48"
+      prompt_reps:
+        description: "iterations for the pp benchmark"
+        required: false
+        default: "6"
+
+permissions:
+  contents: read
+
+env:
+  # The Q8_0 model whose vec_dot kernel the SIMD work targets. Small enough to
+  # fetch per run, quantized so it exercises the integer dot path.
+  MODEL_URL: https://huggingface.co/Qwen/Qwen2.5-0.5B-Instruct-GGUF/resolve/main/qwen2.5-0.5b-instruct-q8_0.gguf
+  MODEL_PATH: testdata/qwen2.5-0.5b-instruct-q8_0.gguf
+
+jobs:
+  bench:
+    name: Bench (${{ matrix.name }})
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: amd64 GOAMD64=v2 (SSE4.1)
+            runner: ubuntu-latest
+            goamd64: v2
+          - name: arm64 (native)
+            runner: ubuntu-24.04-arm
+            goamd64: ""
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: CPU capabilities
+        run: |
+          echo "=== uname ==="; uname -m
+          echo "=== lscpu ==="; lscpu || true
+          echo "=== SIMD flags ==="
+          if [ "$(uname -m)" = "x86_64" ]; then
+            grep -om1 -E 'flags.*' /proc/cpuinfo | tr ' ' '\n' \
+              | grep -E '^(sse4_2|avx|avx2|avx512f|avx512bw|avx512vl|avx512vnni|avx_vnni|amx_int8)$' | sort -u \
+              | sed 's/^/  have: /' || true
+          else
+            grep -om1 -E 'Features.*' /proc/cpuinfo | tr ' ' '\n' \
+              | grep -E '^(asimd|asimddp|i8mm|sve|sve2|bf16)$' | sort -u \
+              | sed 's/^/  have: /' || true
+          fi
+
+      - name: Point at a llamawasm2go ref
+        if: ${{ inputs.llamawasm2go_ref != '' }}
+        run: |
+          go get github.com/goccy/llamawasm2go@${{ inputs.llamawasm2go_ref }}
+          go mod tidy
+          echo "llamawasm2go now:"; go list -m github.com/goccy/llamawasm2go
+
+      - name: Fetch Q8_0 model
+        run: |
+          mkdir -p testdata
+          curl -fSL --proto '=https' --tlsv1.2 -o "$MODEL_PATH" "$MODEL_URL"
+          ls -la "$MODEL_PATH"
+
+      - name: Benchmark
+        env:
+          GOAMD64: ${{ matrix.goamd64 }}
+          GO_LLAMA_TEST_MODEL: ${{ github.workspace }}/${{ env.MODEL_PATH }}
+        run: |
+          echo "### tg (token generation) ###"
+          go test -run=NONE -bench='BenchmarkDecode$' \
+            -benchtime=${{ inputs.decode_tokens }}x -count=3 -timeout=30m . | tee tg.txt
+          echo "### pp (prompt processing) ###"
+          go test -run=NONE -bench='BenchmarkPromptEval$' \
+            -benchtime=${{ inputs.prompt_reps }}x -count=3 -timeout=30m . | tee pp.txt
+
+      - name: Summary
+        if: always()
+        run: |
+          {
+            echo "## ${{ matrix.name }}";
+            echo '```';
+            grep -hE 'tok/s|prompt_tok/s' tg.txt pp.txt 2>/dev/null || echo "(no results)";
+            echo '```';
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -89,6 +89,44 @@ jobs:
       # A 4-token decode with a tight timeout: on a pathological
       # runner/bundle combination this fails in seconds with the CPU
       # model already printed, instead of wedging the long benches.
+      # Sequential-read bandwidth of this runner (GB/s). Token
+      # generation streams the whole model per token, so if this number
+      # times model size explains the tok/s, tg is DRAM-bound and no
+      # kernel change can move it.
+      - name: Memory bandwidth probe
+        timeout-minutes: 5
+        run: |
+          mkdir -p /tmp/bwprobe && cat > /tmp/bwprobe/main.go <<'GO'
+          package main
+
+          import (
+          	"fmt"
+          	"time"
+          )
+
+          func main() {
+          	const n = 1 << 27 // 1 GiB of uint64
+          	buf := make([]uint64, n)
+          	for i := range buf {
+          		buf[i] = uint64(i)
+          	}
+          	var sum uint64
+          	best := 0.0
+          	for pass := 0; pass < 5; pass++ {
+          		t := time.Now()
+          		for _, v := range buf {
+          			sum += v
+          		}
+          		gbs := 8 * float64(n) / time.Since(t).Seconds() / 1e9
+          		if gbs > best {
+          			best = gbs
+          		}
+          	}
+          	fmt.Printf("sequential read: %.2f GB/s (sum %d)\n", best, sum)
+          }
+          GO
+          cd /tmp/bwprobe && go mod init bwprobe >/dev/null && go run .
+
       - name: Quick probe (4 tokens)
         timeout-minutes: 8
         env:

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -57,6 +57,10 @@ jobs:
       - name: CPU capabilities
         run: |
           echo "=== uname ==="; uname -m
+          echo "=== page size / THP ==="
+          getconf PAGESIZE
+          cat /sys/kernel/mm/transparent_hugepage/enabled 2>/dev/null || true
+          cat /sys/kernel/mm/transparent_hugepage/defrag 2>/dev/null || true
           echo "=== lscpu ==="; lscpu || true
           echo "=== SIMD flags ==="
           if [ "$(uname -m)" = "x86_64" ]; then

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -139,6 +139,53 @@ jobs:
         run: |
           go test -run=NONE -bench='BenchmarkDecode$' -benchtime=4x -count=1 -timeout=7m .
 
+      # Greedy text of a fixed prompt: the fast-math tile kernels are
+      # not bit-exact vs wasm, so cross-check token-level equivalence by
+      # comparing this text across runners (arm64's kernel is the
+      # long-validated reference).
+      - name: Greedy text probe
+        timeout-minutes: 10
+        env:
+          GOAMD64: ${{ matrix.goamd64 }}
+          GO_LLAMA_TEST_MODEL: ${{ github.workspace }}/${{ env.MODEL_PATH }}
+        run: |
+          mkdir -p /tmp/textprobe && cat > /tmp/textprobe/main_test.go <<'GO'
+          package main
+
+          import (
+          	"fmt"
+          	"os"
+          	"path/filepath"
+          	"testing"
+
+          	llama "github.com/goccy/go-llama"
+          )
+
+          func TestGreedyText(t *testing.T) {
+          	model := os.Getenv("GO_LLAMA_TEST_MODEL")
+          	inst, err := llama.New(llama.WithPreopenDir(filepath.Dir(model)))
+          	if err != nil {
+          		t.Fatal(err)
+          	}
+          	m, err := inst.LoadModel(filepath.Base(model))
+          	if err != nil {
+          		t.Fatal(err)
+          	}
+          	ctx, err := m.NewContext(llama.ContextParams{NCtx: 256})
+          	if err != nil {
+          		t.Fatal(err)
+          	}
+          	res, err := ctx.Generate("The quick brown fox", llama.Params{NPredict: 24, Temperature: 0})
+          	if err != nil {
+          		t.Fatal(err)
+          	}
+          	fmt.Printf("GREEDY24: %q\n", res.Text)
+          }
+          GO
+          cp /tmp/textprobe/main_test.go ./greedy_probe_test.go
+          go test -run TestGreedyText -v -count=1 . | grep -E "GREEDY24|FAIL|ok "
+          rm -f ./greedy_probe_test.go
+
       - name: Benchmark (candidate)
         timeout-minutes: 30
         env:

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -89,10 +89,10 @@ jobs:
         run: |
           echo "### tg (token generation) ###"
           go test -run=NONE -bench='BenchmarkDecode$' \
-            -benchtime=${{ inputs.decode_tokens }}x -count=3 -timeout=30m . | tee tg.txt
+            -benchtime=${{ inputs.decode_tokens || '48' }}x -count=3 -timeout=30m . | tee tg.txt
           echo "### pp (prompt processing) ###"
           go test -run=NONE -bench='BenchmarkPromptEval$' \
-            -benchtime=${{ inputs.prompt_reps }}x -count=3 -timeout=30m . | tee pp.txt
+            -benchtime=${{ inputs.prompt_reps || '6' }}x -count=3 -timeout=30m . | tee pp.txt
 
       - name: Summary
         if: always()

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -106,6 +106,20 @@ jobs:
           go tool pprof -top -nodecount=30 go-llama.test cpu.prof
           echo "### top-15 cumulative ###"
           go tool pprof -top -cum -nodecount=15 go-llama.test cpu.prof
+          echo "### hot-kernel disasm (per-instruction cycles) ###"
+          KERN=$(go tool pprof -top -nodecount=1 go-llama.test cpu.prof | awk 'END{print $NF}')
+          go tool pprof -disasm "$KERN" go-llama.test cpu.prof 2>/dev/null | awk '$1 != "." && $1 != "" {print}' | head -120
+
+      - name: CPU profile (prompt)
+        env:
+          GOAMD64: ${{ matrix.goamd64 }}
+          GO_LLAMA_TEST_MODEL: ${{ github.workspace }}/${{ env.MODEL_PATH }}
+        run: |
+          go test -run=NONE -bench='BenchmarkPromptEval$' \
+            -benchtime=2x -count=1 -timeout=60m \
+            -cpuprofile=pp.prof .
+          echo "### pp top-20 flat ###"
+          go tool pprof -top -nodecount=20 go-llama.test pp.prof
 
       - name: Summary
         if: always()

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -241,6 +241,9 @@ jobs:
             -cpuprofile=pp.prof .
           echo "### pp top-20 flat ###"
           go tool pprof -top -nodecount=20 go-llama.test pp.prof
+          echo "### pp hot-kernel disasm ###"
+          KERN=$(go tool pprof -top -nodecount=1 go-llama.test pp.prof | awk 'END{print $NF}')
+          go tool pprof -disasm "$KERN" go-llama.test pp.prof 2>/dev/null | awk '$1 != "." && $1 != "" {print}' | sort -k1 -rh | head -40
 
       - name: Summary
         if: always()

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -94,6 +94,19 @@ jobs:
           go test -run=NONE -bench='BenchmarkPromptEval$' \
             -benchtime=${{ inputs.prompt_reps || '6' }}x -count=3 -timeout=30m . | tee pp.txt
 
+      - name: CPU profile (decode)
+        env:
+          GOAMD64: ${{ matrix.goamd64 }}
+          GO_LLAMA_TEST_MODEL: ${{ github.workspace }}/${{ env.MODEL_PATH }}
+        run: |
+          go test -run=NONE -bench='BenchmarkDecode$' \
+            -benchtime=${{ inputs.decode_tokens || '48' }}x -count=1 -timeout=30m \
+            -cpuprofile=cpu.prof .
+          echo "### top-30 flat ###"
+          go tool pprof -top -nodecount=30 go-llama.test cpu.prof
+          echo "### top-15 cumulative ###"
+          go tool pprof -top -cum -nodecount=15 go-llama.test cpu.prof
+
       - name: Summary
         if: always()
         run: |

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -149,8 +149,9 @@ jobs:
           GOAMD64: ${{ matrix.goamd64 }}
           GO_LLAMA_TEST_MODEL: ${{ github.workspace }}/${{ env.MODEL_PATH }}
         run: |
+          set -o pipefail
           mkdir -p /tmp/textprobe && cat > /tmp/textprobe/main_test.go <<'GO'
-          package main
+          package llama_test
 
           import (
           	"fmt"

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -61,7 +61,7 @@ jobs:
           echo "=== SIMD flags ==="
           if [ "$(uname -m)" = "x86_64" ]; then
             grep -om1 -E 'flags.*' /proc/cpuinfo | tr ' ' '\n' \
-              | grep -E '^(sse4_2|avx|avx2|avx512f|avx512bw|avx512vl|avx512vnni|avx_vnni|amx_int8)$' | sort -u \
+              | grep -E '^(sse4_2|avx|avx2|avx512f|avx512bw|avx512vl|avx512_vnni|avx512vnni|avx_vnni|amx_int8)$' | sort -u \
               | sed 's/^/  have: /' || true
           else
             grep -om1 -E 'Features.*' /proc/cpuinfo | tr ' ' '\n' \
@@ -82,17 +82,35 @@ jobs:
           curl -fSL --proto '=https' --tlsv1.2 -o "$MODEL_PATH" "$MODEL_URL"
           ls -la "$MODEL_PATH"
 
-      - name: Benchmark
+      # Candidate (the go.mod pin) and the v0.1.0 baseline run back to
+      # back IN THE SAME JOB: the amd64 runner pool mixes CPU
+      # generations (EPYC 7763 Zen 3 vs 9V74 Zen 4, ~30% apart), so
+      # only same-runner deltas are meaningful.
+      - name: Benchmark (candidate)
         env:
           GOAMD64: ${{ matrix.goamd64 }}
           GO_LLAMA_TEST_MODEL: ${{ github.workspace }}/${{ env.MODEL_PATH }}
         run: |
-          echo "### tg (token generation) ###"
+          echo "### candidate: $(go list -m github.com/goccy/llamawasm2go) ###"
           go test -run=NONE -bench='BenchmarkDecode$' \
-            -benchtime=${{ inputs.decode_tokens || '48' }}x -count=3 -timeout=30m . | tee tg.txt
-          echo "### pp (prompt processing) ###"
+            -benchtime=${{ inputs.decode_tokens || '48' }}x -count=2 -timeout=30m . | tee tg.txt
           go test -run=NONE -bench='BenchmarkPromptEval$' \
-            -benchtime=${{ inputs.prompt_reps || '6' }}x -count=3 -timeout=30m . | tee pp.txt
+            -benchtime=${{ inputs.prompt_reps || '6' }}x -count=1 -timeout=30m . | tee pp.txt
+
+      - name: Benchmark (v0.1.0 baseline, same runner)
+        env:
+          GOAMD64: ${{ matrix.goamd64 }}
+          GO_LLAMA_TEST_MODEL: ${{ github.workspace }}/${{ env.MODEL_PATH }}
+          GOFLAGS: -mod=mod
+        run: |
+          go get github.com/goccy/llamawasm2go@v0.1.0
+          go mod tidy
+          echo "### baseline: $(go list -m github.com/goccy/llamawasm2go) ###"
+          go test -run=NONE -bench='BenchmarkDecode$' \
+            -benchtime=${{ inputs.decode_tokens || '48' }}x -count=2 -timeout=30m . | tee tg-base.txt
+          go test -run=NONE -bench='BenchmarkPromptEval$' \
+            -benchtime=${{ inputs.prompt_reps || '6' }}x -count=1 -timeout=30m . | tee pp-base.txt
+          git checkout -- go.mod go.sum
 
       - name: CPU profile (decode)
         env:
@@ -127,6 +145,9 @@ jobs:
           {
             echo "## ${{ matrix.name }}";
             echo '```';
+            echo "candidate:";
             grep -hE 'tok/s|prompt_tok/s' tg.txt pp.txt 2>/dev/null || echo "(no results)";
+            echo "baseline v0.1.0 (same runner):";
+            grep -hE 'tok/s|prompt_tok/s' tg-base.txt pp-base.txt 2>/dev/null || echo "(no results)";
             echo '```';
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -86,7 +86,19 @@ jobs:
       # back IN THE SAME JOB: the amd64 runner pool mixes CPU
       # generations (EPYC 7763 Zen 3 vs 9V74 Zen 4, ~30% apart), so
       # only same-runner deltas are meaningful.
+      # A 4-token decode with a tight timeout: on a pathological
+      # runner/bundle combination this fails in seconds with the CPU
+      # model already printed, instead of wedging the long benches.
+      - name: Quick probe (4 tokens)
+        timeout-minutes: 8
+        env:
+          GOAMD64: ${{ matrix.goamd64 }}
+          GO_LLAMA_TEST_MODEL: ${{ github.workspace }}/${{ env.MODEL_PATH }}
+        run: |
+          go test -run=NONE -bench='BenchmarkDecode$' -benchtime=4x -count=1 -timeout=7m .
+
       - name: Benchmark (candidate)
+        timeout-minutes: 30
         env:
           GOAMD64: ${{ matrix.goamd64 }}
           GO_LLAMA_TEST_MODEL: ${{ github.workspace }}/${{ env.MODEL_PATH }}
@@ -98,6 +110,7 @@ jobs:
             -benchtime=${{ inputs.prompt_reps || '6' }}x -count=1 -timeout=30m . | tee pp.txt
 
       - name: Benchmark (v0.1.0 baseline, same runner)
+        timeout-minutes: 30
         env:
           GOAMD64: ${{ matrix.goamd64 }}
           GO_LLAMA_TEST_MODEL: ${{ github.workspace }}/${{ env.MODEL_PATH }}

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/goccy/go-llama
 
 go 1.25.0
 
-require github.com/goccy/llamawasm2go v0.0.0-20260815064808-00146caff69f
+require github.com/goccy/llamawasm2go v0.0.0-20260815080441-54f9ad7e670e

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/goccy/go-llama
 
 go 1.25.0
 
-require github.com/goccy/llamawasm2go v0.0.0-20260815141021-d354e887f1a6
+require github.com/goccy/llamawasm2go v0.0.0-20260815150400-5f5dbd73832f

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/goccy/go-llama
 
 go 1.25.0
 
-require github.com/goccy/llamawasm2go v0.0.0-20260815000414-4856d907510e
+require github.com/goccy/llamawasm2go v0.0.0-20260815064808-00146caff69f

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/goccy/go-llama
 
 go 1.25.0
 
-require github.com/goccy/llamawasm2go v0.0.0-20260815080441-54f9ad7e670e
+require github.com/goccy/llamawasm2go v0.0.0-20260815121410-c39a25a1fb45

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/goccy/go-llama
 
 go 1.25.0
 
-require github.com/goccy/llamawasm2go v0.0.0-20260814180946-658985017d23
+require github.com/goccy/llamawasm2go v0.0.0-20260815000414-4856d907510e

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/goccy/go-llama
 
 go 1.25.0
 
-require github.com/goccy/llamawasm2go v0.0.0-20260815163404-246f62088875
+require github.com/goccy/llamawasm2go v0.1.1-0.20260821031834-841af79208a1

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/goccy/go-llama
 
 go 1.25.0
 
-require github.com/goccy/llamawasm2go v0.0.0-20260814111837-5ff146e22517
+require github.com/goccy/llamawasm2go v0.0.0-20260814180946-658985017d23

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/goccy/go-llama
 
 go 1.25.0
 
-require github.com/goccy/llamawasm2go v0.0.0-20260815121410-c39a25a1fb45
+require github.com/goccy/llamawasm2go v0.0.0-20260815133501-ac6bad4c9204

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/goccy/go-llama
 
 go 1.25.0
 
-require github.com/goccy/llamawasm2go v0.0.0-20260815153414-2feb44159b02
+require github.com/goccy/llamawasm2go v0.0.0-20260815163404-246f62088875

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/goccy/go-llama
 
 go 1.25.0
 
-require github.com/goccy/llamawasm2go v0.0.0-20260815150400-5f5dbd73832f
+require github.com/goccy/llamawasm2go v0.0.0-20260815153414-2feb44159b02

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/goccy/go-llama
 
 go 1.25.0
 
-require github.com/goccy/llamawasm2go v0.1.0
+require github.com/goccy/llamawasm2go v0.0.0-20260814111837-5ff146e22517

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/goccy/go-llama
 
 go 1.25.0
 
-require github.com/goccy/llamawasm2go v0.0.0-20260815133501-ac6bad4c9204
+require github.com/goccy/llamawasm2go v0.0.0-20260815141021-d354e887f1a6

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/goccy/llamawasm2go v0.0.0-20260815153414-2feb44159b02 h1:X2FDeAEdHi3oxgPNeMvrvZMAIWhUQ74yc0eLO0VuLz4=
-github.com/goccy/llamawasm2go v0.0.0-20260815153414-2feb44159b02/go.mod h1:2RraXBB/RS2RBlIol/M/rNvIcdtatKWzt8g7q63MPm0=
+github.com/goccy/llamawasm2go v0.0.0-20260815163404-246f62088875 h1:HwFmD45dQuVZ41X0Wt6DQEgCSavDTsrjM6UInlS8/bQ=
+github.com/goccy/llamawasm2go v0.0.0-20260815163404-246f62088875/go.mod h1:2RraXBB/RS2RBlIol/M/rNvIcdtatKWzt8g7q63MPm0=

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/goccy/llamawasm2go v0.0.0-20260815064808-00146caff69f h1:ZLCQyWqbnmrL+h2drBGt8uL3Y2Xser/CcLLWyCsg7CQ=
-github.com/goccy/llamawasm2go v0.0.0-20260815064808-00146caff69f/go.mod h1:2RraXBB/RS2RBlIol/M/rNvIcdtatKWzt8g7q63MPm0=
+github.com/goccy/llamawasm2go v0.0.0-20260815080441-54f9ad7e670e h1:nrD6aa6xY04Obl0iXLVpWqjXw9ZmvQMYXNASRe+LNhY=
+github.com/goccy/llamawasm2go v0.0.0-20260815080441-54f9ad7e670e/go.mod h1:2RraXBB/RS2RBlIol/M/rNvIcdtatKWzt8g7q63MPm0=

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/goccy/llamawasm2go v0.0.0-20260815163404-246f62088875 h1:HwFmD45dQuVZ41X0Wt6DQEgCSavDTsrjM6UInlS8/bQ=
-github.com/goccy/llamawasm2go v0.0.0-20260815163404-246f62088875/go.mod h1:2RraXBB/RS2RBlIol/M/rNvIcdtatKWzt8g7q63MPm0=
+github.com/goccy/llamawasm2go v0.1.1-0.20260821031834-841af79208a1 h1:bcB11p1bDrNS7B4tUJp7fmIJ0TVMWGj5MwPuym6v3PM=
+github.com/goccy/llamawasm2go v0.1.1-0.20260821031834-841af79208a1/go.mod h1:2RraXBB/RS2RBlIol/M/rNvIcdtatKWzt8g7q63MPm0=

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/goccy/llamawasm2go v0.0.0-20260814111837-5ff146e22517 h1:1W67OgmjJ55V1ADB3QzNEisEKUCW2zXK5uO3twZVHvk=
-github.com/goccy/llamawasm2go v0.0.0-20260814111837-5ff146e22517/go.mod h1:2RraXBB/RS2RBlIol/M/rNvIcdtatKWzt8g7q63MPm0=
+github.com/goccy/llamawasm2go v0.0.0-20260814180946-658985017d23 h1:A/31Zf+JdmuPuPQL4nb8t5Fl8M65aR6C5bX9yhzRjag=
+github.com/goccy/llamawasm2go v0.0.0-20260814180946-658985017d23/go.mod h1:2RraXBB/RS2RBlIol/M/rNvIcdtatKWzt8g7q63MPm0=

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/goccy/llamawasm2go v0.0.0-20260815080441-54f9ad7e670e h1:nrD6aa6xY04Obl0iXLVpWqjXw9ZmvQMYXNASRe+LNhY=
-github.com/goccy/llamawasm2go v0.0.0-20260815080441-54f9ad7e670e/go.mod h1:2RraXBB/RS2RBlIol/M/rNvIcdtatKWzt8g7q63MPm0=
+github.com/goccy/llamawasm2go v0.0.0-20260815121410-c39a25a1fb45 h1:U3qrDwCEdE0hO8pD8CJmNsgUSFh40vgETcyRLSyxm3w=
+github.com/goccy/llamawasm2go v0.0.0-20260815121410-c39a25a1fb45/go.mod h1:2RraXBB/RS2RBlIol/M/rNvIcdtatKWzt8g7q63MPm0=

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/goccy/llamawasm2go v0.0.0-20260815150400-5f5dbd73832f h1:dQTz/pWgXXTmt0mjYrxJ6vyXB6Oz8FLDRfbDJ4ndf8I=
-github.com/goccy/llamawasm2go v0.0.0-20260815150400-5f5dbd73832f/go.mod h1:2RraXBB/RS2RBlIol/M/rNvIcdtatKWzt8g7q63MPm0=
+github.com/goccy/llamawasm2go v0.0.0-20260815153414-2feb44159b02 h1:X2FDeAEdHi3oxgPNeMvrvZMAIWhUQ74yc0eLO0VuLz4=
+github.com/goccy/llamawasm2go v0.0.0-20260815153414-2feb44159b02/go.mod h1:2RraXBB/RS2RBlIol/M/rNvIcdtatKWzt8g7q63MPm0=

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/goccy/llamawasm2go v0.1.0 h1:MMSqpq3jr7R85MhJCe6PlSKcPXA9AyfJ/74gCC3QCJ8=
-github.com/goccy/llamawasm2go v0.1.0/go.mod h1:2RraXBB/RS2RBlIol/M/rNvIcdtatKWzt8g7q63MPm0=
+github.com/goccy/llamawasm2go v0.0.0-20260814111837-5ff146e22517 h1:1W67OgmjJ55V1ADB3QzNEisEKUCW2zXK5uO3twZVHvk=
+github.com/goccy/llamawasm2go v0.0.0-20260814111837-5ff146e22517/go.mod h1:2RraXBB/RS2RBlIol/M/rNvIcdtatKWzt8g7q63MPm0=

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/goccy/llamawasm2go v0.0.0-20260814180946-658985017d23 h1:A/31Zf+JdmuPuPQL4nb8t5Fl8M65aR6C5bX9yhzRjag=
-github.com/goccy/llamawasm2go v0.0.0-20260814180946-658985017d23/go.mod h1:2RraXBB/RS2RBlIol/M/rNvIcdtatKWzt8g7q63MPm0=
+github.com/goccy/llamawasm2go v0.0.0-20260815000414-4856d907510e h1:AmRHSFZwNpEtIT9hUkFa9Q5T22+e/Vg7Ft9/a6ZA3s0=
+github.com/goccy/llamawasm2go v0.0.0-20260815000414-4856d907510e/go.mod h1:2RraXBB/RS2RBlIol/M/rNvIcdtatKWzt8g7q63MPm0=

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/goccy/llamawasm2go v0.0.0-20260815141021-d354e887f1a6 h1:F78ymEFClQWFLngWvWM1dESkYHPJMBckvsWJyVgm+z4=
-github.com/goccy/llamawasm2go v0.0.0-20260815141021-d354e887f1a6/go.mod h1:2RraXBB/RS2RBlIol/M/rNvIcdtatKWzt8g7q63MPm0=
+github.com/goccy/llamawasm2go v0.0.0-20260815150400-5f5dbd73832f h1:dQTz/pWgXXTmt0mjYrxJ6vyXB6Oz8FLDRfbDJ4ndf8I=
+github.com/goccy/llamawasm2go v0.0.0-20260815150400-5f5dbd73832f/go.mod h1:2RraXBB/RS2RBlIol/M/rNvIcdtatKWzt8g7q63MPm0=

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/goccy/llamawasm2go v0.0.0-20260815000414-4856d907510e h1:AmRHSFZwNpEtIT9hUkFa9Q5T22+e/Vg7Ft9/a6ZA3s0=
-github.com/goccy/llamawasm2go v0.0.0-20260815000414-4856d907510e/go.mod h1:2RraXBB/RS2RBlIol/M/rNvIcdtatKWzt8g7q63MPm0=
+github.com/goccy/llamawasm2go v0.0.0-20260815064808-00146caff69f h1:ZLCQyWqbnmrL+h2drBGt8uL3Y2Xser/CcLLWyCsg7CQ=
+github.com/goccy/llamawasm2go v0.0.0-20260815064808-00146caff69f/go.mod h1:2RraXBB/RS2RBlIol/M/rNvIcdtatKWzt8g7q63MPm0=

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/goccy/llamawasm2go v0.0.0-20260815133501-ac6bad4c9204 h1:u8KDEDgKDOHbyYcrG7Jy6FpV+vicAkksEOwWPPdiFZk=
-github.com/goccy/llamawasm2go v0.0.0-20260815133501-ac6bad4c9204/go.mod h1:2RraXBB/RS2RBlIol/M/rNvIcdtatKWzt8g7q63MPm0=
+github.com/goccy/llamawasm2go v0.0.0-20260815141021-d354e887f1a6 h1:F78ymEFClQWFLngWvWM1dESkYHPJMBckvsWJyVgm+z4=
+github.com/goccy/llamawasm2go v0.0.0-20260815141021-d354e887f1a6/go.mod h1:2RraXBB/RS2RBlIol/M/rNvIcdtatKWzt8g7q63MPm0=

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/goccy/llamawasm2go v0.0.0-20260815121410-c39a25a1fb45 h1:U3qrDwCEdE0hO8pD8CJmNsgUSFh40vgETcyRLSyxm3w=
-github.com/goccy/llamawasm2go v0.0.0-20260815121410-c39a25a1fb45/go.mod h1:2RraXBB/RS2RBlIol/M/rNvIcdtatKWzt8g7q63MPm0=
+github.com/goccy/llamawasm2go v0.0.0-20260815133501-ac6bad4c9204 h1:u8KDEDgKDOHbyYcrG7Jy6FpV+vicAkksEOwWPPdiFZk=
+github.com/goccy/llamawasm2go v0.0.0-20260815133501-ac6bad4c9204/go.mod h1:2RraXBB/RS2RBlIol/M/rNvIcdtatKWzt8g7q63MPm0=


### PR DESCRIPTION
Draft to run the full go-llama suite on the amd64 AVX2 llamawasm2go bundle (wasm2go feat/amd64-avx2-dot8) across GOAMD64 v1/v2 + arm64. Validates the AVX2 8-bit dot is bit-correct on real amd64 hardware. The go.mod pin is temporary; reverts to v0.1.0 before any real change lands.