### PR TITLE
Bump llamawasm2go to v0.1.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/goccy/go-llama
 
 go 1.25.0
 
-require github.com/goccy/llamawasm2go v0.1.0
+require github.com/goccy/llamawasm2go v0.1.1

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,4 @@
 github.com/goccy/llamawasm2go v0.1.0 h1:MMSqpq3jr7R85MhJCe6PlSKcPXA9AyfJ/74gCC3QCJ8=
 github.com/goccy/llamawasm2go v0.1.0/go.mod h1:2RraXBB/RS2RBlIol/M/rNvIcdtatKWzt8g7q63MPm0=
+github.com/goccy/llamawasm2go v0.1.1 h1:DxsJnsTeAjcz0zA1hBFevLHopF/BA+PEWVMDJOZWAR4=
+github.com/goccy/llamawasm2go v0.1.1/go.mod h1:2RraXBB/RS2RBlIol/M/rNvIcdtatKWzt8g7q63MPm0=


### PR DESCRIPTION
## Summary

Updates the engine bundle from llamawasm2go v0.1.0 to **v0.1.1** — the bundle regenerated from the llama-wasm v0.1.1 release with wasm2go v0.5.2, which adds the amd64 AVX2 / AVX-512-VNNI fused SIMD backend with runtime CPU dispatch.

## Performance (same-runner CI A/B, qwen2.5-0.5b q8_0)

| runner | metric | v0.1.0 | v0.1.1 |
|---|---|---|---|
| amd64 Zen 4 (VNNI) | decode | 10.9 | **22.9 tok/s** (beats arm64 17.3) |
| amd64 Zen 4 (VNNI) | prompt | 15.3 | **40.1 tok/s** (beats arm64 36.3) |
| amd64 Zen 3 (no VNNI) | decode | 9.1 | **15.9 tok/s** |
| amd64 Zen 3 (no VNNI) | prompt | 12.8 | **26.3 tok/s** |
| arm64 Neoverse | decode / prompt | 17.4 / 36.3 | 17.5 / 36.3 (unchanged) |

Greedy continuations remain byte-identical across architectures and versions. amd64 SIMD requires `GOAMD64=v2` as before; pre-AVX2 CPUs are handled at runtime by the portable SSE bodies.

## Verification

- Full test suite passes natively on arm64 with the new bundle (including the qwen-model sampler/verify tests, which CI skips for lack of the model)
- Bundle provenance verified upstream: sha256 manifest + SLSA attestation against the llama-wasm release workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)