### PR TITLE
Adopt the llamawasm2go v0.2.3 engine bundle: transpiler-guarded spin loops

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Version of goccy/llama-wasm whose release assets this package is built from.
 # Bump it, run `make llama`, and commit the regenerated bridge.
 LLAMA_WASM_REPO     ?= goccy/llama-wasm
-LLAMA_WASM_VERSION  ?= v0.1.0
+LLAMA_WASM_VERSION  ?= v0.2.6
 LLAMA_WASM_WORKFLOW ?= goccy/llama-wasm/.github/workflows/release.yml
 
 # The generated wasm2go bridge. It is a release artifact of llama-wasm, not

--- a/gcstress_test.go
+++ b/gcstress_test.go
@@ -1,0 +1,90 @@
+package llama_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"runtime"
+	"testing"
+	"time"
+
+	llama "github.com/goccy/go-llama"
+)
+
+// TestGenerateSurvivesGCPressure pins the engine's stop-the-world
+// behavior: a multi-threaded generate must make progress while the Go
+// GC constantly stops the world. Engine bundles before llamawasm2go
+// v0.2.3 livelocked here — ggml's barrier spin-waits were captured
+// into assembly the runtime cannot async-preempt, so a worker spinning
+// at a barrier blocked every stop-the-world while the worker it waited
+// for stayed parked, and the process burned every core forever. The
+// engine's transpiler now plants a bounded preemption point in those
+// spins, so the run below completes in well under a second of work.
+//
+// The scenario runs in a CHILD process with the deadline held by the
+// parent, because the failure mode freezes the child's entire runtime:
+// no goroutine runs during the wedged stop-the-world, so in-process
+// timers — including go test's own -test.timeout — never fire. Only an
+// external observer can turn the hang into a failure. The deadline is
+// deliberately generous (the GOAMD64=v1 scalar fallback is slow); a
+// healthy engine finishes orders of magnitude sooner, and a wedged one
+// never finishes at all.
+func TestGenerateSurvivesGCPressure(t *testing.T) {
+	if os.Getenv("GO_LLAMA_GC_STRESS_CHILD") == "1" {
+		gcStressChild(t)
+		return
+	}
+
+	if _, err := os.Stat(modelPath()); err != nil {
+		t.Skipf("test model missing (%v); run `make testdata` or set GO_LLAMA_TEST_MODEL", err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, os.Args[0],
+		"-test.run", "^TestGenerateSurvivesGCPressure$", "-test.v")
+	cmd.Env = append(os.Environ(), "GO_LLAMA_GC_STRESS_CHILD=1")
+	out, err := cmd.CombinedOutput()
+	if ctx.Err() == context.DeadlineExceeded {
+		t.Fatalf("stop-the-world livelock: the GC-pressure generate did not finish "+
+			"within 90s and was killed from outside — the engine's spin-waits are "+
+			"not preemptible\nchild output:\n%s", out)
+	}
+	if err != nil {
+		t.Fatalf("GC-pressure child failed: %v\n%s", err, out)
+	}
+}
+
+// gcStressChild is the in-child half: hammer runtime.GC from one
+// goroutine — every cycle is a stop-the-world request racing the
+// engine's barrier spins — while a threaded context generates.
+func gcStressChild(t *testing.T) {
+	m := load(t)
+	ctx, err := m.NewContext(llama.ContextParams{NCtx: 256, NThreads: 4})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ctx.Close()
+
+	stop := make(chan struct{})
+	defer close(stop)
+	go func() {
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				runtime.GC()
+			}
+		}
+	}()
+
+	res, err := ctx.Generate("Once upon a time", llama.Params{NPredict: 32, Temperature: 0})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.NDecoded == 0 {
+		t.Fatal("generate under GC pressure decoded no tokens")
+	}
+	fmt.Printf("generated %d tokens under GC pressure\n", res.NDecoded)
+}

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/goccy/go-llama
 
 go 1.25.0
 
-require github.com/goccy/llamawasm2go v0.2.2
+require github.com/goccy/llamawasm2go v0.2.3

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/goccy/llamawasm2go v0.2.2 h1:LPig+yhXOmDCubjxqcoQIRhiq1AR0eY4qoHvVHyYm9M=
-github.com/goccy/llamawasm2go v0.2.2/go.mod h1:2RraXBB/RS2RBlIol/M/rNvIcdtatKWzt8g7q63MPm0=
+github.com/goccy/llamawasm2go v0.2.3 h1:p8b6an3LOmWvpvxNgj2k9jl6CiQMxDTw7wpph01AEoI=
+github.com/goccy/llamawasm2go v0.2.3/go.mod h1:2RraXBB/RS2RBlIol/M/rNvIcdtatKWzt8g7q63MPm0=


### PR DESCRIPTION
Bumps the engine to llamawasm2go v0.2.3, which carries the llama-wasm v0.2.6 bundle — the first built with wasm2go v0.5.7's bare-atomic-spin preemption guard (goccy/wasm2go#55, goccy/llama-wasm#12, goccy/llamawasm2go#8).

## What this fixes

Multi-threaded decode (`ContextParams.NThreads > 1`) could livelock: ggml's barrier spin-waits compile to call-free atomic loops, the gcasm bundler captures them into assembly the Go runtime cannot async-preempt, and a worker spinning at a barrier blocked every stop-the-world while the worker it waited for stayed parked — intermittent multi-minute stalls at 100% CPU, GC-timing dependent. The transpiler now plants a bounded preemption point in every such loop (a stop-the-world waits tens of microseconds of spinning, not forever). The v0.2.6 engine also keeps the per-context threadpool at `poll=0`: idle contexts no longer spin between graphs, taking 8-live-context steady-state per-call latency from 4.3s to ~0.12s.

## Changes

- `go.mod`: llamawasm2go v0.2.2 → v0.2.3.
- `Makefile`: the bridge pin (`LLAMA_WASM_VERSION`) moves v0.1.0 → v0.2.6. The committed `internal/llama.go` is byte-identical to v0.2.6's release asset (the API surface never changed) and re-verifies against that release's attestation — `make verify` passes against the new pin.

## Verification (against the released module, no replace)

- Full suite green on `GOAMD64=v2` and native arm64 (root + internal, including the local-only qwen compat/verify tests CI skips).
- A `runtime.GC()`-hammer repro over an 8-thread generate — which wedges the v0.2.2 engine forever (700% CPU, undetectable from inside the process) — completes in ~0.5s.
- Interleaved same-conditions A/B at n_threads=8 over 8 live contexts: at or below the unguarded engine (which itself sat at ~115–120ms per 16-token call on an idle machine).

🤖 Generated with [Claude Code](https://claude.com/claude-code)