### PR TITLE
Build the shared images in place and adopt the llamawasm2go v0.2.4 engine

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Version of goccy/llama-wasm whose release assets this package is built from.
 # Bump it, run `make llama`, and commit the regenerated bridge.
 LLAMA_WASM_REPO     ?= goccy/llama-wasm
-LLAMA_WASM_VERSION  ?= v0.2.6
+LLAMA_WASM_VERSION  ?= v0.2.7
 LLAMA_WASM_WORKFLOW ?= goccy/llama-wasm/.github/workflows/release.yml
 
 # The generated wasm2go bridge. It is a release artifact of llama-wasm, not

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/goccy/go-llama
 
 go 1.25.0
 
-require github.com/goccy/llamawasm2go v0.2.3
+require github.com/goccy/llamawasm2go v0.2.4

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/goccy/llamawasm2go v0.2.3 h1:p8b6an3LOmWvpvxNgj2k9jl6CiQMxDTw7wpph01AEoI=
-github.com/goccy/llamawasm2go v0.2.3/go.mod h1:2RraXBB/RS2RBlIol/M/rNvIcdtatKWzt8g7q63MPm0=
+github.com/goccy/llamawasm2go v0.2.4 h1:aqCm2bvuIlzPJd48pFE3ZBK+OjwqDtpyasSATu1eOtE=
+github.com/goccy/llamawasm2go v0.2.4/go.mod h1:2RraXBB/RS2RBlIol/M/rNvIcdtatKWzt8g7q63MPm0=

--- a/internal/sharedengine.go
+++ b/internal/sharedengine.go
@@ -91,7 +91,7 @@ func mapSharedMemory(img *base.SharedImage, opts Options) ([]byte, error) {
 // first use. The builder runs only the start section (Initialize): instances
 // run WasmInit themselves, with their own WASI.
 func sharedEngineImage() *base.SharedImage {
-	return base.NewSharedImage(func() (g *base.Module, err error) {
+	return base.NewSharedImageInPlace(defaultMemoryCeiling, func(mem []byte) (g *base.Module, err error) {
 		if sharedImagesDisabled() {
 			return nil, fmt.Errorf("disabled by GO_LLAMA_NO_SHARED_IMAGE")
 		}
@@ -100,8 +100,13 @@ func sharedEngineImage() *base.SharedImage {
 				g, err = nil, fmt.Errorf("the engine's start section panicked: %v", r)
 			}
 		}()
+		// The builder runs directly on the image file's shared mapping (mem):
+		// every page it writes IS the image, so building costs exactly the
+		// pages the start section touches — no ceiling-sized allocation, no
+		// copy. See base.NewSharedImageInPlace.
 		m := &Module{}
-		m.g = wasm2go.NewWithWASI(base.DefaultWASI(), envStubs{m: m}, wasmifyStubs{m: m})
+		m.g = wasm2go.NewWithMemory(base.DefaultWASI(), envStubs{m: m}, wasmifyStubs{m: m},
+			mem, wasm2go.InitialMemoryBytes)
 		wasm2go.Initialize(m.g)
 		return m.g, nil
 	})
@@ -150,17 +155,20 @@ func buildModelSnapshot(opts Options, load func(*Module) (uint64, error)) *Model
 		return &ModelSnapshot{err: fmt.Errorf("disabled by GO_LLAMA_NO_SHARED_IMAGE")}
 	}
 	var handle uint64
-	img := base.NewSharedSnapshot(func() (g *base.Module, err error) {
+	img := base.NewSharedSnapshotInPlace(memoryCeiling(opts), func(mem []byte) (g *base.Module, err error) {
 		defer func() {
 			if r := recover(); r != nil {
 				g, err = nil, fmt.Errorf("starting the engine to snapshot panicked: %v", r)
 			}
 		}()
-		// The builder engine is private on purpose: buildSharedImage copies its
-		// memory and discards the instance, and a private allocation is the Go
-		// heap's to reclaim — an image-backed builder would leak its mapping.
-		m, err := newPrivateEngine(opts)
-		if err != nil {
+		// The builder runs directly on the snapshot file's shared mapping:
+		// the engine boots and loads the model straight into the image, so
+		// the snapshot costs exactly the pages the build touches — once,
+		// file-backed — instead of a private build plus a ceiling-sized copy.
+		m := &Module{}
+		m.g = wasm2go.NewWithMemory(engineWASI(opts), envStubs{m: m}, wasmifyStubs{m: m},
+			mem, wasm2go.InitialMemoryBytes)
+		if err := initEngine(m); err != nil {
 			return nil, err
 		}
 		h, err := load(m)


### PR DESCRIPTION
Adopts llamawasm2go v0.2.4 (llama-wasm v0.2.7 / wasm2go v0.5.8 — goccy/wasm2go#56, goccy/llamawasm2go#9) and switches both copy-on-write image tiers to the engine's new **in-place builders**.

## What this fixes

Building the engine and model images used to boot a throwaway builder engine on a private ceiling-length allocation (8 GiB for this engine), copy its memory, and discard it. The Go allocator zeroes reused ceiling-sized heap spans, so every process paid **~8 GB of dirty resident pages regardless of model size** — nondeterministically attributed across stages, and invisible until RSS was actually measured. With the in-place builders the throwaway engine writes directly into the image file's shared mapping: building an image costs exactly the pages the build touches, file-backed and evictable.

## Changes

- `internal/sharedengine.go`: both tiers (data-segment image at `New`, per-model snapshot at first `LoadModel`) build through `NewSharedImageInPlace` / `NewSharedSnapshotInPlace` with `NewWithMemory` + `InitialMemoryBytes`.
- `go.mod`: llamawasm2go v0.2.3 → v0.2.4. `Makefile`: bridge pin v0.2.6 → v0.2.7 (`internal/llama.go` is byte-identical to the v0.2.7 asset and re-verifies against its attestation — `make verify` passes).

## Measured (arm64, released module, no replace)

| stage | before this work | now |
|---|---|---|
| `New` (engine init) | 5.0–8.2 GB (nondeterministic) | **9.4 MB** |
| qwen2.5-0.5b q8_0 steady state (1 instance + contexts + generate) | ~9.4 GB | **~1.4 GB** |
| stories260K end-to-end | ~8.2 GB | **20 MB** |
| second instance, same model | — | **~0** |
| two models A+B | — | images additive; each model's later instances ~0 |

Full suite green (`GOAMD64=v2` + native arm64, root + internal, including `TestGenerateSurvivesGCPressure`); the GC-pressure livelock repro completes in ~0.5 s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)