### PR TITLE
Add instance snapshots: NewSnapshot / Snapshot.Fork

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Version of goccy/llama-wasm whose release assets this package is built from.
 # Bump it, run `make llama`, and commit the regenerated bridge.
 LLAMA_WASM_REPO     ?= goccy/llama-wasm
-LLAMA_WASM_VERSION  ?= v0.2.7
+LLAMA_WASM_VERSION  ?= v0.2.8
 LLAMA_WASM_WORKFLOW ?= goccy/llama-wasm/.github/workflows/release.yml
 
 # The generated wasm2go bridge. It is a release artifact of llama-wasm, not

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/goccy/go-llama
 
 go 1.25.0
 
-require github.com/goccy/llamawasm2go v0.2.4
+require github.com/goccy/llamawasm2go v0.2.5

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/goccy/llamawasm2go v0.2.4 h1:aqCm2bvuIlzPJd48pFE3ZBK+OjwqDtpyasSATu1eOtE=
-github.com/goccy/llamawasm2go v0.2.4/go.mod h1:2RraXBB/RS2RBlIol/M/rNvIcdtatKWzt8g7q63MPm0=
+github.com/goccy/llamawasm2go v0.2.5 h1:sHMsNI3OVqZ2UO7MZwF4esBw8Vh3xFCjUX1/3qYZuxU=
+github.com/goccy/llamawasm2go v0.2.5/go.mod h1:2RraXBB/RS2RBlIol/M/rNvIcdtatKWzt8g7q63MPm0=

--- a/internal/engine.go
+++ b/internal/engine.go
@@ -32,6 +32,7 @@ import (
 // the iota order must match llama.go's Inv_0_0, Inv_0_1, ... exactly.
 const (
 	midChatApplyTemplate int32 = iota
+	midCtxAttachThreadpool
 	midCtxEmbed
 	midCtxEmbedTokens
 	midCtxEval
@@ -66,32 +67,33 @@ const (
 // after a regeneration; nothing else in this file names an Inv_0_* directly.
 var invokers = [midCount]func(*base.Module, wptr, wptr) (int64, error){
 	midChatApplyTemplate:      wasm2go.Inv_0_0,
-	midCtxEmbed:               wasm2go.Inv_0_1,
-	midCtxEmbedTokens:         wasm2go.Inv_0_2,
-	midCtxEval:                wasm2go.Inv_0_3,
-	midCtxFree:                wasm2go.Inv_0_4,
-	midCtxGenerate:            wasm2go.Inv_0_5,
-	midCtxGenerateSpeculative: wasm2go.Inv_0_6,
-	midCtxInterruptAddr:       wasm2go.Inv_0_7,
-	midCtxLoraSet:             wasm2go.Inv_0_8,
-	midCtxNew:                 wasm2go.Inv_0_9,
-	midCtxReset:               wasm2go.Inv_0_10,
-	midCtxScore:               wasm2go.Inv_0_11,
-	midCtxStateLoad:           wasm2go.Inv_0_12,
-	midCtxStateSave:           wasm2go.Inv_0_13,
-	midDetokenize:             wasm2go.Inv_0_14,
-	midLoraFree:               wasm2go.Inv_0_15,
-	midLoraLoad:               wasm2go.Inv_0_16,
-	midModelFree:              wasm2go.Inv_0_17,
-	midModelInfo:              wasm2go.Inv_0_18,
-	midModelLoad:              wasm2go.Inv_0_19,
-	midModelLoadProgressAddr:  wasm2go.Inv_0_20,
-	midTokenToPiece:           wasm2go.Inv_0_21,
-	midTokenize:               wasm2go.Inv_0_22,
-	midWasmBuildInfo:          wasm2go.Inv_0_23,
-	midWasmFree:               wasm2go.Inv_0_24,
-	midWasmInit:               wasm2go.Inv_0_25,
-	midWasmLastError:          wasm2go.Inv_0_26,
+	midCtxAttachThreadpool:    wasm2go.Inv_0_1,
+	midCtxEmbed:               wasm2go.Inv_0_2,
+	midCtxEmbedTokens:         wasm2go.Inv_0_3,
+	midCtxEval:                wasm2go.Inv_0_4,
+	midCtxFree:                wasm2go.Inv_0_5,
+	midCtxGenerate:            wasm2go.Inv_0_6,
+	midCtxGenerateSpeculative: wasm2go.Inv_0_7,
+	midCtxInterruptAddr:       wasm2go.Inv_0_8,
+	midCtxLoraSet:             wasm2go.Inv_0_9,
+	midCtxNew:                 wasm2go.Inv_0_10,
+	midCtxReset:               wasm2go.Inv_0_11,
+	midCtxScore:               wasm2go.Inv_0_12,
+	midCtxStateLoad:           wasm2go.Inv_0_13,
+	midCtxStateSave:           wasm2go.Inv_0_14,
+	midDetokenize:             wasm2go.Inv_0_15,
+	midLoraFree:               wasm2go.Inv_0_16,
+	midLoraLoad:               wasm2go.Inv_0_17,
+	midModelFree:              wasm2go.Inv_0_18,
+	midModelInfo:              wasm2go.Inv_0_19,
+	midModelLoad:              wasm2go.Inv_0_20,
+	midModelLoadProgressAddr:  wasm2go.Inv_0_21,
+	midTokenToPiece:           wasm2go.Inv_0_22,
+	midTokenize:               wasm2go.Inv_0_23,
+	midWasmBuildInfo:          wasm2go.Inv_0_24,
+	midWasmFree:               wasm2go.Inv_0_25,
+	midWasmInit:               wasm2go.Inv_0_26,
+	midWasmLastError:          wasm2go.Inv_0_27,
 }
 
 // NewEngine brings up an independent engine instance: its own wasm module
@@ -385,14 +387,25 @@ func (m *Module) LlamaCtxGenerateSpeculative(ctx uint64, draftCtx uint64, prompt
 	return readScalarAtField(resp, 1, (*pbReader).readString), nil
 }
 
-func (m *Module) LlamaCtxInterruptAddr(ctx uint64) (uint32, error) {
+func (m *Module) LlamaCtxAttachThreadpool(ctx uint64, nThreads uint32) (string, error) {
+	buf := pbNewBuf()
+	buf = pbAppendUint64(buf, 1, ctx)
+	buf = pbAppendUint64(buf, 2, uint64(nThreads))
+	resp, err := m.invokeMethod(midCtxAttachThreadpool, buf)
+	if err != nil {
+		return "", err
+	}
+	return readScalarAtField(resp, 1, (*pbReader).readString), nil
+}
+
+func (m *Module) LlamaCtxInterruptAddr(ctx uint64) (uint64, error) {
 	buf := pbNewBuf()
 	buf = pbAppendUint64(buf, 1, ctx)
 	resp, err := m.invokeMethod(midCtxInterruptAddr, buf)
 	if err != nil {
 		return 0, err
 	}
-	return readScalarAtField(resp, 1, (*pbReader).readUint32), nil
+	return readScalarAtField(resp, 1, (*pbReader).readUint64), nil
 }
 
 func (m *Module) LlamaCtxLoraSet(ctx uint64, adaptersJson string, adaptersJsonLen uint32) (string, error) {
@@ -522,13 +535,13 @@ func (m *Module) LlamaModelLoad(path string, pathLen uint32, nGpuLayers int32, u
 	return readScalarAtField(resp, 1, (*pbReader).readUint64), nil
 }
 
-func (m *Module) LlamaModelLoadProgressAddr() (uint32, error) {
+func (m *Module) LlamaModelLoadProgressAddr() (uint64, error) {
 	buf := pbNewBuf()
 	resp, err := m.invokeMethod(midModelLoadProgressAddr, buf)
 	if err != nil {
 		return 0, err
 	}
-	return readScalarAtField(resp, 1, (*pbReader).readUint32), nil
+	return readScalarAtField(resp, 1, (*pbReader).readUint64), nil
 }
 
 func (m *Module) LlamaTokenToPiece(model uint64, token int32, renderSpecial int32) (string, error) {

--- a/internal/gemv_repack_numeric_test.go
+++ b/internal/gemv_repack_numeric_test.go
@@ -26,7 +26,7 @@ import (
 // recorded in the llama-wasm release build log); it moves with any
 // engine rebuild, so re-read it from the log (or the bundle's
 // load32_splat memarg offsets) when bumping the bundle dependency.
-const repackF16Table = 8793040
+const repackF16Table = 8793152
 
 func f16Bits(f float32) uint16 {
 	// Exact for the small power-of-two scales the tests use.

--- a/internal/llama.go
+++ b/internal/llama.go
@@ -981,13 +981,36 @@ func LlamaChatApplyTemplate(model uint64, messagesJson string, messagesJsonLen u
 	return readScalarAtField(resp, 1, (*pbReader).readString), nil
 }
 
+// Rebuild and attach the context's ggml threadpool. An instance forked
+//
+//	from a snapshot inherits the memory image of a context whose pool
+//	references worker threads of the snapshot builder; those threads do not
+//	exist in this process, so the next decode (or the join inside
+//	llama_ctx_free) would wait forever. Call this right after forking: it
+//	creates a fresh pool with n_threads workers (poll=0, as llama_ctx_new)
+//	and attaches it, ABANDONING the inherited pool struct -- its memory is
+//	shared snapshot pages and its dead threads cannot be joined. n_threads
+//
+// <
+// = 1 detaches instead. Returns {"ok":true} or an error object.
+func LlamaCtxAttachThreadpool(ctx uint64, nThreads uint32) (string, error) {
+	buf := pbNewBuf()
+	buf = pbAppendUint64(buf, 1, ctx)
+	buf = pbAppendUint64(buf, 2, uint64(nThreads))
+	resp, err := invokeMethod(0, 1, buf, wasm2go.Inv_0_1)
+	if err != nil {
+		return "", err
+	}
+	return readScalarAtField(resp, 1, (*pbReader).readString), nil
+}
+
 func LlamaCtxEmbed(ctx uint64, text string, textLen uint32, normalize int32) (string, error) {
 	buf := pbNewBuf()
 	buf = pbAppendUint64(buf, 1, ctx)
 	buf = pbAppendString(buf, 2, text)
 	buf = pbAppendUint64(buf, 3, uint64(textLen))
 	buf = pbAppendInt32(buf, 4, normalize)
-	resp, err := invokeMethod(0, 1, buf, wasm2go.Inv_0_1)
+	resp, err := invokeMethod(0, 2, buf, wasm2go.Inv_0_2)
 	if err != nil {
 		return "", err
 	}
@@ -1002,7 +1025,7 @@ func LlamaCtxEmbedTokens(ctx uint64, tokensJson string, tokensJsonLen uint32, no
 	buf = pbAppendString(buf, 2, tokensJson)
 	buf = pbAppendUint64(buf, 3, uint64(tokensJsonLen))
 	buf = pbAppendInt32(buf, 4, normalize)
-	resp, err := invokeMethod(0, 2, buf, wasm2go.Inv_0_2)
+	resp, err := invokeMethod(0, 3, buf, wasm2go.Inv_0_3)
 	if err != nil {
 		return "", err
 	}
@@ -1021,7 +1044,7 @@ func LlamaCtxEval(ctx uint64, text string, textLen uint32, addSpecial int32, par
 	buf = pbAppendUint64(buf, 3, uint64(textLen))
 	buf = pbAppendInt32(buf, 4, addSpecial)
 	buf = pbAppendInt32(buf, 5, parseSpecial)
-	resp, err := invokeMethod(0, 3, buf, wasm2go.Inv_0_3)
+	resp, err := invokeMethod(0, 4, buf, wasm2go.Inv_0_4)
 	if err != nil {
 		return "", err
 	}
@@ -1032,7 +1055,7 @@ func LlamaCtxEval(ctx uint64, text string, textLen uint32, addSpecial int32, par
 func LlamaCtxFree(ctx uint64) error {
 	buf := pbNewBuf()
 	buf = pbAppendUint64(buf, 1, ctx)
-	_, err := invokeMethod(0, 4, buf, wasm2go.Inv_0_4)
+	_, err := invokeMethod(0, 5, buf, wasm2go.Inv_0_5)
 	return err
 }
 
@@ -1075,7 +1098,7 @@ func LlamaCtxGenerate(ctx uint64, prompt string, promptLen uint32, paramsJson st
 	buf = pbAppendString(buf, 4, paramsJson)
 	buf = pbAppendUint64(buf, 5, uint64(paramsJsonLen))
 	buf = pbAppendHandlePtr(buf, 6, sink)
-	resp, err := invokeMethod(0, 5, buf, wasm2go.Inv_0_5)
+	resp, err := invokeMethod(0, 6, buf, wasm2go.Inv_0_6)
 	if err != nil {
 		return "", err
 	}
@@ -1102,7 +1125,7 @@ func LlamaCtxGenerateSpeculative(ctx uint64, draftCtx uint64, prompt string, pro
 	buf = pbAppendUint64(buf, 6, uint64(paramsJsonLen))
 	buf = pbAppendInt32(buf, 7, nDraft)
 	buf = pbAppendHandlePtr(buf, 8, sink)
-	resp, err := invokeMethod(0, 6, buf, wasm2go.Inv_0_6)
+	resp, err := invokeMethod(0, 7, buf, wasm2go.Inv_0_7)
 	if err != nil {
 		return "", err
 	}
@@ -1113,14 +1136,14 @@ func LlamaCtxGenerateSpeculative(ctx uint64, draftCtx uint64, prompt string, pro
 // Writing a non-zero value from another thread makes the running
 // llama_ctx_generate stop at its next token and return what it has, with
 // `"interrupted":true`. The generation loop clears the flag when it starts.
-func LlamaCtxInterruptAddr(ctx uint64) (uint32, error) {
+func LlamaCtxInterruptAddr(ctx uint64) (uint64, error) {
 	buf := pbNewBuf()
 	buf = pbAppendUint64(buf, 1, ctx)
-	resp, err := invokeMethod(0, 7, buf, wasm2go.Inv_0_7)
+	resp, err := invokeMethod(0, 8, buf, wasm2go.Inv_0_8)
 	if err != nil {
 		return 0, err
 	}
-	return readScalarAtField(resp, 1, (*pbReader).readUint32), nil
+	return readScalarAtField(resp, 1, (*pbReader).readUint64), nil
 }
 
 // Set the FULL adapter configuration of a context: `adapters_json` is
@@ -1130,7 +1153,7 @@ func LlamaCtxLoraSet(ctx uint64, adaptersJson string, adaptersJsonLen uint32) (s
 	buf = pbAppendUint64(buf, 1, ctx)
 	buf = pbAppendString(buf, 2, adaptersJson)
 	buf = pbAppendUint64(buf, 3, uint64(adaptersJsonLen))
-	resp, err := invokeMethod(0, 8, buf, wasm2go.Inv_0_8)
+	resp, err := invokeMethod(0, 9, buf, wasm2go.Inv_0_9)
 	if err != nil {
 		return "", err
 	}
@@ -1152,7 +1175,7 @@ func LlamaCtxNew(model uint64, paramsJson string, paramsJsonLen uint32) (uint64,
 	buf = pbAppendUint64(buf, 1, model)
 	buf = pbAppendString(buf, 2, paramsJson)
 	buf = pbAppendUint64(buf, 3, uint64(paramsJsonLen))
-	resp, err := invokeMethod(0, 9, buf, wasm2go.Inv_0_9)
+	resp, err := invokeMethod(0, 10, buf, wasm2go.Inv_0_10)
 	if err != nil {
 		return 0, err
 	}
@@ -1163,7 +1186,7 @@ func LlamaCtxNew(model uint64, paramsJson string, paramsJsonLen uint32) (uint64,
 func LlamaCtxReset(ctx uint64) error {
 	buf := pbNewBuf()
 	buf = pbAppendUint64(buf, 1, ctx)
-	_, err := invokeMethod(0, 10, buf, wasm2go.Inv_0_10)
+	_, err := invokeMethod(0, 11, buf, wasm2go.Inv_0_11)
 	return err
 }
 
@@ -1182,7 +1205,7 @@ func LlamaCtxScore(ctx uint64, text string, textLen uint32) (string, error) {
 	buf = pbAppendUint64(buf, 1, ctx)
 	buf = pbAppendString(buf, 2, text)
 	buf = pbAppendUint64(buf, 3, uint64(textLen))
-	resp, err := invokeMethod(0, 11, buf, wasm2go.Inv_0_11)
+	resp, err := invokeMethod(0, 12, buf, wasm2go.Inv_0_12)
 	if err != nil {
 		return "", err
 	}
@@ -1200,7 +1223,7 @@ func LlamaCtxStateLoad(ctx uint64, data string, size uint32) (string, error) {
 	buf = pbAppendUint64(buf, 1, ctx)
 	buf = pbAppendString(buf, 2, data)
 	buf = pbAppendUint64(buf, 3, uint64(size))
-	resp, err := invokeMethod(0, 12, buf, wasm2go.Inv_0_12)
+	resp, err := invokeMethod(0, 13, buf, wasm2go.Inv_0_13)
 	if err != nil {
 		return "", err
 	}
@@ -1216,7 +1239,7 @@ func LlamaCtxStateLoad(ctx uint64, data string, size uint32) (string, error) {
 func LlamaCtxStateSave(ctx uint64) (string, error) {
 	buf := pbNewBuf()
 	buf = pbAppendUint64(buf, 1, ctx)
-	resp, err := invokeMethod(0, 13, buf, wasm2go.Inv_0_13)
+	resp, err := invokeMethod(0, 14, buf, wasm2go.Inv_0_14)
 	if err != nil {
 		return "", err
 	}
@@ -1231,7 +1254,7 @@ func LlamaDetokenize(model uint64, tokensJson string, tokensJsonLen uint32, rend
 	buf = pbAppendString(buf, 2, tokensJson)
 	buf = pbAppendUint64(buf, 3, uint64(tokensJsonLen))
 	buf = pbAppendInt32(buf, 4, renderSpecial)
-	resp, err := invokeMethod(0, 14, buf, wasm2go.Inv_0_14)
+	resp, err := invokeMethod(0, 15, buf, wasm2go.Inv_0_15)
 	if err != nil {
 		return "", err
 	}
@@ -1243,7 +1266,7 @@ func LlamaDetokenize(model uint64, tokensJson string, tokensJsonLen uint32, rend
 func LlamaLoraFree(adapter uint64) error {
 	buf := pbNewBuf()
 	buf = pbAppendUint64(buf, 1, adapter)
-	_, err := invokeMethod(0, 15, buf, wasm2go.Inv_0_15)
+	_, err := invokeMethod(0, 16, buf, wasm2go.Inv_0_16)
 	return err
 }
 
@@ -1254,7 +1277,7 @@ func LlamaLoraLoad(model uint64, path string, pathLen uint32) (uint64, error) {
 	buf = pbAppendUint64(buf, 1, model)
 	buf = pbAppendString(buf, 2, path)
 	buf = pbAppendUint64(buf, 3, uint64(pathLen))
-	resp, err := invokeMethod(0, 16, buf, wasm2go.Inv_0_16)
+	resp, err := invokeMethod(0, 17, buf, wasm2go.Inv_0_17)
 	if err != nil {
 		return 0, err
 	}
@@ -1265,7 +1288,7 @@ func LlamaLoraLoad(model uint64, path string, pathLen uint32) (uint64, error) {
 func LlamaModelFree(model uint64) error {
 	buf := pbNewBuf()
 	buf = pbAppendUint64(buf, 1, model)
-	_, err := invokeMethod(0, 17, buf, wasm2go.Inv_0_17)
+	_, err := invokeMethod(0, 18, buf, wasm2go.Inv_0_18)
 	return err
 }
 
@@ -1275,7 +1298,7 @@ func LlamaModelFree(model uint64) error {
 func LlamaModelInfo(model uint64) (string, error) {
 	buf := pbNewBuf()
 	buf = pbAppendUint64(buf, 1, model)
-	resp, err := invokeMethod(0, 18, buf, wasm2go.Inv_0_18)
+	resp, err := invokeMethod(0, 19, buf, wasm2go.Inv_0_19)
 	if err != nil {
 		return "", err
 	}
@@ -1297,7 +1320,7 @@ func LlamaModelLoad(path string, pathLen uint32, nGpuLayers int32, useMmap int32
 	buf = pbAppendUint64(buf, 2, uint64(pathLen))
 	buf = pbAppendInt32(buf, 3, nGpuLayers)
 	buf = pbAppendInt32(buf, 4, useMmap)
-	resp, err := invokeMethod(0, 19, buf, wasm2go.Inv_0_19)
+	resp, err := invokeMethod(0, 20, buf, wasm2go.Inv_0_20)
 	if err != nil {
 		return 0, err
 	}
@@ -1307,13 +1330,13 @@ func LlamaModelLoad(path string, pathLen uint32, nGpuLayers int32, useMmap int32
 // Address, in linear memory, of a float the loader updates with its progress
 // (0.0 .. 1.0) while llama_model_load runs. A host thread can poll it to drive
 // a progress bar. Valid for the lifetime of the wasm instance.
-func LlamaModelLoadProgressAddr() (uint32, error) {
+func LlamaModelLoadProgressAddr() (uint64, error) {
 	buf := pbNewBuf()
-	resp, err := invokeMethod(0, 20, buf, wasm2go.Inv_0_20)
+	resp, err := invokeMethod(0, 21, buf, wasm2go.Inv_0_21)
 	if err != nil {
 		return 0, err
 	}
-	return readScalarAtField(resp, 1, (*pbReader).readUint32), nil
+	return readScalarAtField(resp, 1, (*pbReader).readUint64), nil
 }
 
 // The text piece a single token renders to, as JSON `{"ok":true,"text":".."}`.
@@ -1324,7 +1347,7 @@ func LlamaTokenToPiece(model uint64, token int32, renderSpecial int32) (string, 
 	buf = pbAppendUint64(buf, 1, model)
 	buf = pbAppendInt32(buf, 2, token)
 	buf = pbAppendInt32(buf, 3, renderSpecial)
-	resp, err := invokeMethod(0, 21, buf, wasm2go.Inv_0_21)
+	resp, err := invokeMethod(0, 22, buf, wasm2go.Inv_0_22)
 	if err != nil {
 		return "", err
 	}
@@ -1341,7 +1364,7 @@ func LlamaTokenize(model uint64, text string, textLen uint32, addSpecial int32, 
 	buf = pbAppendUint64(buf, 3, uint64(textLen))
 	buf = pbAppendInt32(buf, 4, addSpecial)
 	buf = pbAppendInt32(buf, 5, parseSpecial)
-	resp, err := invokeMethod(0, 22, buf, wasm2go.Inv_0_22)
+	resp, err := invokeMethod(0, 23, buf, wasm2go.Inv_0_23)
 	if err != nil {
 		return "", err
 	}
@@ -1352,7 +1375,7 @@ func LlamaTokenize(model uint64, text string, textLen uint32, addSpecial int32, 
 // and whether this wasm was built with SIMD / threads. Diagnostics only.
 func LlamaWasmBuildInfo() (string, error) {
 	buf := pbNewBuf()
-	resp, err := invokeMethod(0, 23, buf, wasm2go.Inv_0_23)
+	resp, err := invokeMethod(0, 24, buf, wasm2go.Inv_0_24)
 	if err != nil {
 		return "", err
 	}
@@ -1362,7 +1385,7 @@ func LlamaWasmBuildInfo() (string, error) {
 // Free process-wide backend state. After this every handle is invalid.
 func LlamaWasmFree() error {
 	buf := pbNewBuf()
-	_, err := invokeMethod(0, 24, buf, wasm2go.Inv_0_24)
+	_, err := invokeMethod(0, 25, buf, wasm2go.Inv_0_25)
 	return err
 }
 
@@ -1370,7 +1393,7 @@ func LlamaWasmFree() error {
 // llama_model_load, so an embedder normally never calls it.
 func LlamaWasmInit() error {
 	buf := pbNewBuf()
-	_, err := invokeMethod(0, 25, buf, wasm2go.Inv_0_25)
+	_, err := invokeMethod(0, 26, buf, wasm2go.Inv_0_26)
 	return err
 }
 
@@ -1379,7 +1402,7 @@ func LlamaWasmInit() error {
 // this exists for the handle-returning calls, which can only signal 0.
 func LlamaWasmLastError() (string, error) {
 	buf := pbNewBuf()
-	resp, err := invokeMethod(0, 26, buf, wasm2go.Inv_0_26)
+	resp, err := invokeMethod(0, 27, buf, wasm2go.Inv_0_27)
 	if err != nil {
 		return "", err
 	}

--- a/internal/sharedengine.go
+++ b/internal/sharedengine.go
@@ -205,3 +205,62 @@ func NewEngineFromModelSnapshot(snap *ModelSnapshot, opts Options) (*Module, err
 	engineMmaps.Store(m, mem)
 	return m, nil
 }
+
+// --- copy-on-write instance snapshot (prepared contexts shared) -------------
+
+// InstanceSnapshot is a copy-on-write image of a fully prepared engine:
+// model loaded, contexts created and primed with their prompt prefixes,
+// whatever else the build did. Where ModelSnapshot shares the loaded
+// weights, this shares the whole prepared instance — an engine built from
+// it starts exactly where the build stopped, so engines forked from it pay
+// only for the pages they write.
+type InstanceSnapshot struct {
+	img *base.SharedImage
+}
+
+// BuildInstanceSnapshot boots an engine directly on a snapshot image and
+// hands it to build to prepare (load a model, create and prime contexts).
+// The handles build records remain valid in every engine created from the
+// snapshot. There is no process-wide registry: the caller owns the snapshot
+// and its lifetime.
+func BuildInstanceSnapshot(opts Options, build func(*Module) error) (*InstanceSnapshot, error) {
+	if sharedImagesDisabled() {
+		return nil, fmt.Errorf("disabled by GO_LLAMA_NO_SHARED_IMAGE")
+	}
+	img := base.NewSharedSnapshotInPlace(memoryCeiling(opts), func(mem []byte) (g *base.Module, err error) {
+		defer func() {
+			if r := recover(); r != nil {
+				g, err = nil, fmt.Errorf("preparing the engine to snapshot panicked: %v", r)
+			}
+		}()
+		m := &Module{}
+		m.g = wasm2go.NewWithMemory(engineWASI(opts), envStubs{m: m}, wasmifyStubs{m: m},
+			mem, wasm2go.InitialMemoryBytes)
+		if err := initEngine(m); err != nil {
+			return nil, err
+		}
+		if err := build(m); err != nil {
+			return nil, err
+		}
+		return m.g, nil
+	})
+	if err := img.Err(); err != nil {
+		return nil, err
+	}
+	return &InstanceSnapshot{img: img}, nil
+}
+
+// NewEngineFromInstanceSnapshot brings up an engine as a copy-on-write map
+// of snap: prepared contexts and all, nothing re-run. opts supplies THIS
+// engine's WASI.
+func NewEngineFromInstanceSnapshot(snap *InstanceSnapshot, opts Options) (*Module, error) {
+	mem, err := mapSharedMemory(snap.img, opts)
+	if err != nil {
+		return nil, err
+	}
+	m := &Module{}
+	m.g = wasm2go.NewFromSnapshot(engineWASI(opts), envStubs{m: m}, wasmifyStubs{m: m},
+		mem, snap.img.Size(), snap.img.Globals())
+	engineMmaps.Store(m, mem)
+	return m, nil
+}

--- a/llama.go
+++ b/llama.go
@@ -64,6 +64,11 @@ type config struct {
 	stdout, stderr     io.Writer
 	memoryReserveBytes int
 	maxMemoryBytes     uint64
+	// noSharedModel makes LoadModel load into this instance's own memory even
+	// for the first model, instead of adopting the process-wide model
+	// snapshot. Snapshot builders set it: their memory IS the image being
+	// built, and swapping engines mid-build would capture the wrong one.
+	noSharedModel bool
 }
 
 // An Option configures a Llama at New time.
@@ -237,7 +242,7 @@ type Context struct {
 	// interruptAddr is the linear-memory address of this context's interrupt
 	// flag, resolved once at creation so Interrupt never has to call into the
 	// engine — which it could not do while a generation is inside it.
-	interruptAddr uint32
+	interruptAddr uint64
 
 	closed atomic.Bool
 }
@@ -270,7 +275,7 @@ func (l *Llama) LoadModel(path string) (*Model, error) {
 	// instead of loading the weights again; the first pays one extra copy of
 	// the loaded memory into the image. Any failure here falls back to the
 	// private load below.
-	if l.models == 0 && l.cfg.fs == nil {
+	if l.models == 0 && l.cfg.fs == nil && !l.cfg.noSharedModel {
 		key := fmt.Sprintf("dir=%q|env=%q|model=%q", l.cfg.preopenDir, l.cfg.env, guestPath)
 		snap := bridge.SharedModelSnapshot(key, l.cfg.bridgeOptions(true),
 			func(m *bridge.Module) (uint64, error) {
@@ -712,7 +717,7 @@ func (c *Context) SaveState() ([]byte, error) {
 	}
 	var out struct {
 		envelope
-		Addr uint32 `json:"addr"`
+		Addr uint64 `json:"addr"`
 		Size uint32 `json:"size"`
 	}
 	if err := decode("save state", js, &out); err != nil {

--- a/snapshot.go
+++ b/snapshot.go
@@ -1,0 +1,175 @@
+package llama
+
+import (
+	"errors"
+	"fmt"
+	"runtime"
+	"sort"
+
+	bridge "github.com/goccy/go-llama/internal"
+)
+
+// Instance snapshots: prepare once, fork many times.
+//
+// An engine instance serialises every call, so the unit of parallelism is
+// the instance — but preparing one the ordinary way (create a context,
+// restore a prompt-prefix state) writes tens of MB of private pages per
+// instance: the KV cache is allocated and zeroed anew, and the prefix state
+// is copied into it. A Snapshot removes that: NewSnapshot prepares an
+// engine ONCE — model loaded, contexts created, prefixes decoded — and
+// captures it as a copy-on-write image. Fork then brings up an engine that
+// starts exactly there: the prepared KV caches are shared pages, and a
+// fork pays only for what it writes (its suffix's KV entries and the
+// compute scratch), typically an order of magnitude less.
+//
+// Worker threads do not survive a snapshot — they are host constructs, not
+// memory. NewSnapshot therefore detaches every kept context's threadpool
+// before capturing (a fork that skips reattaching merely runs
+// single-threaded), and Fork attaches a fresh pool with the requested
+// thread count.
+
+// SnapshotBuilder is the instance handed to a NewSnapshot callback: a normal
+// *Llama plus Register, which records the contexts forks will use.
+type SnapshotBuilder struct {
+	*Llama
+	kept map[string]keptContext
+}
+
+type keptContext struct {
+	modelH uint64
+	ctxH   uint64
+}
+
+// Register records a prepared context under name, making it available from
+// every fork of the snapshot via Instance.Context(name).
+func (b *SnapshotBuilder) Register(name string, c *Context) error {
+	if c == nil || c.closed.Load() {
+		return errors.New("llama: register: context is nil or closed")
+	}
+	if c.model.inst != b.Llama {
+		return errors.New("llama: register: context does not belong to this builder")
+	}
+	if _, dup := b.kept[name]; dup {
+		return fmt.Errorf("llama: register: %q already registered", name)
+	}
+	b.kept[name] = keptContext{modelH: c.model.h, ctxH: c.h}
+	return nil
+}
+
+// Snapshot is the copy-on-write image of a prepared instance. It stays valid
+// for the life of the process; forks reference it and share its pages.
+type Snapshot struct {
+	snap *bridge.InstanceSnapshot
+	cfg  config
+	kept map[string]keptContext
+}
+
+// NewSnapshot boots an engine on a snapshot image and hands it to build to
+// prepare: load the model, create contexts, decode their prompt prefixes
+// (Params.CachePrompt), and Register the ones forks will use. When build
+// returns, every kept context's threadpool is detached (threads are host
+// constructs and cannot be captured) and the image is sealed.
+//
+// The builder instance itself is consumed by the build; do not retain the
+// *Llama, models or contexts it produced beyond the callback.
+func NewSnapshot(build func(*SnapshotBuilder) error, opts ...Option) (*Snapshot, error) {
+	var cfg config
+	for _, o := range opts {
+		o(&cfg)
+	}
+	kept := map[string]keptContext{}
+	snap, err := bridge.BuildInstanceSnapshot(cfg.bridgeOptions(true), func(m *bridge.Module) error {
+		l := &Llama{cfg: cfg}
+		l.cfg.noSharedModel = true // load into THIS image, not the process-wide model snapshot
+		l.eng.Store(m)
+		b := &SnapshotBuilder{Llama: l, kept: kept}
+		if err := build(b); err != nil {
+			return err
+		}
+		if len(kept) == 0 {
+			return errors.New("llama: snapshot build kept no context")
+		}
+		// Threads are not memory: detach every kept context's pool so the
+		// captured state never references the builder's dead workers. A fork
+		// that skips AttachThreadpool then runs single-threaded, safely.
+		names := make([]string, 0, len(kept))
+		for name := range kept {
+			names = append(names, name)
+		}
+		sort.Strings(names)
+		for _, name := range names {
+			if err := attachThreadpool(m, kept[name].ctxH, 1); err != nil {
+				return fmt.Errorf("llama: detach %s: %w", name, err)
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &Snapshot{snap: snap, cfg: cfg, kept: kept}, nil
+}
+
+// Fork brings up an instance from the snapshot: the prepared contexts are
+// live immediately, with fresh threadpools of nThreads workers each
+// (nThreads <= 1 keeps them single-threaded). Close the fork when done
+// with it — its private pages are returned then.
+func (s *Snapshot) Fork(nThreads uint32) (*Instance, error) {
+	eng, err := bridge.NewEngineFromInstanceSnapshot(s.snap, s.cfg.bridgeOptions(false))
+	if err != nil {
+		return nil, fmt.Errorf("llama: fork: %w", err)
+	}
+	l := &Llama{cfg: s.cfg}
+	l.eng.Store(eng)
+	runtime.SetFinalizer(l, func(l *Llama) { l.Close() })
+	f := &Instance{l: l, ctxs: map[string]*Context{}}
+	models := map[uint64]*Model{}
+	for name, k := range s.kept {
+		m, ok := models[k.modelH]
+		if !ok {
+			m = &Model{inst: l, h: k.modelH}
+			models[k.modelH] = m
+			l.models++
+		}
+		c := &Context{model: m, h: k.ctxH}
+		if c.interruptAddr, err = eng.LlamaCtxInterruptAddr(k.ctxH); err != nil || c.interruptAddr == 0 {
+			_ = l.Close()
+			return nil, fmt.Errorf("llama: fork: interrupt address for %s: %v", name, err)
+		}
+		if nThreads > 1 {
+			if err := attachThreadpool(eng, k.ctxH, nThreads); err != nil {
+				_ = l.Close()
+				return nil, fmt.Errorf("llama: fork: attach threadpool for %s: %w", name, err)
+			}
+		}
+		f.ctxs[name] = c
+	}
+	return f, nil
+}
+
+// Instance is one engine instance forked from a Snapshot.
+type Instance struct {
+	l    *Llama
+	ctxs map[string]*Context
+}
+
+// Context returns the kept context by name, or nil.
+func (f *Instance) Context(name string) *Context { return f.ctxs[name] }
+
+// Close releases the fork: its copy-on-write mapping is unmapped, returning
+// every private page. The kept contexts need no individual Close — their
+// backing memory is the mapping itself.
+func (f *Instance) Close() error { return f.l.Close() }
+
+// attachThreadpool rebuilds and attaches a context's ggml threadpool via the
+// bridge; n <= 1 detaches instead.
+func attachThreadpool(m *bridge.Module, ctxH uint64, n uint32) error {
+	js, err := m.LlamaCtxAttachThreadpool(ctxH, n)
+	if err != nil {
+		return err
+	}
+	var out struct {
+		envelope
+	}
+	return decode("attach threadpool", js, &out)
+}

--- a/snapshot_test.go
+++ b/snapshot_test.go
@@ -1,0 +1,97 @@
+package llama_test
+
+import (
+	"strings"
+	"testing"
+
+	llama "github.com/goccy/go-llama"
+)
+
+// TestSnapshotFork checks the prepare-once / fork-per-request path: a fork
+// starts with the builder's context — prefix cached, no re-decode — and
+// generates exactly what a conventionally built instance generates; a fork
+// that skips the threadpool (nThreads 1) still works; forks are independent.
+func TestSnapshotFork(t *testing.T) {
+	prefix := "Once upon a time, in a land far away, there lived a little girl who loved"
+	const suffix = " to sing"
+
+	// Baseline: a conventional instance, greedy.
+	inst := load(t)
+	ctx, err := inst.NewContext(llama.ContextParams{NCtx: 512, NThreads: 2})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ctx.Close()
+	want, err := ctx.Generate(prefix+suffix, llama.Params{NPredict: 8, Temperature: 0})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	snap, err := llama.NewSnapshot(func(b *llama.SnapshotBuilder) error {
+		m, err := b.LoadModel(modelPath())
+		if err != nil {
+			return err
+		}
+		c, err := m.NewContext(llama.ContextParams{NCtx: 512, NThreads: 2})
+		if err != nil {
+			return err
+		}
+		if _, err := c.Generate(prefix, llama.Params{NPredict: 1, CachePrompt: true, Temperature: 0}); err != nil {
+			return err
+		}
+		return b.Register("main", c)
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, nThreads := range []uint32{2, 1} {
+		f, err := snap.Fork(nThreads)
+		if err != nil {
+			t.Fatalf("Fork(%d): %v", nThreads, err)
+		}
+		c := f.Context("main")
+		if c == nil {
+			t.Fatal("kept context missing in fork")
+		}
+		res, err := c.Generate(prefix+suffix, llama.Params{NPredict: 8, CachePrompt: true, Temperature: 0})
+		if err != nil {
+			t.Fatalf("fork(%d) generate: %v", nThreads, err)
+		}
+		if res.NCached == 0 {
+			t.Fatalf("fork(%d): prefix not cached (n_cached=0)", nThreads)
+		}
+		if res.Text != want.Text {
+			t.Fatalf("fork(%d) text = %q, want %q", nThreads, res.Text, want.Text)
+		}
+		if err := f.Close(); err != nil {
+			t.Fatalf("close fork: %v", err)
+		}
+	}
+
+	// Two live forks answer independently.
+	f1, err := snap.Fork(2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f1.Close()
+	f2, err := snap.Fork(2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f2.Close()
+	r1, err := f1.Context("main").Generate(prefix+" to dance", llama.Params{NPredict: 8, CachePrompt: true, Temperature: 0})
+	if err != nil {
+		t.Fatal(err)
+	}
+	r2, err := f2.Context("main").Generate(prefix+suffix, llama.Params{NPredict: 8, CachePrompt: true, Temperature: 0})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r2.Text != want.Text {
+		t.Fatalf("fork2 text = %q, want %q", r2.Text, want.Text)
+	}
+	if strings.TrimSpace(r1.Text) == "" {
+		t.Fatal("fork1 produced nothing")
+	}
+}


### PR DESCRIPTION
New public API for cheap concurrent instances: prepare an engine once, then fork copy-on-write clones of the whole prepared instance.

```go
snap, _ := llama.NewSnapshot(func(b *llama.SnapshotBuilder) error {
    m, _ := b.LoadModel(path)
    c, _ := m.NewContext(llama.ContextParams{NCtx: 2048})
    c.Generate(prefix, llama.Params{NPredict: 1, CachePrompt: true})
    return b.Register("main", c)
})

inst, _ := snap.Fork(8)          // instance with "main" live, prefix cached
defer inst.Close()
inst.Context("main").Generate(prefix+suffix, params)
```

## Why

An engine instance serialises every call, so the unit of parallelism is the instance — but preparing one conventionally (new context, prefix decoded or state-restored) writes tens of MB of private pages each time: the KV cache is allocated and zeroed anew, and any state blob is staged through linear memory. A fork starts where the build stopped: the prepared KV caches are shared pages, and it pays only for what it writes (measured ~an order of magnitude less private memory per instance).

## How

- `internal.BuildInstanceSnapshot` boots the builder engine directly on a snapshot image (`base.NewSharedSnapshotInPlace`); handles recorded during the build stay valid in every engine mapped from it. The builder sets `noSharedModel` — its memory IS the image, so the process-wide model snapshot must not swap engines mid-build.
- Worker threads are host constructs and do not survive the image: `NewSnapshot` detaches each registered context's threadpool before capture, and `Snapshot.Fork` reattaches fresh pools through the bridge's new `llama_ctx_attach_threadpool` (an `Instance` that skips it just runs single-threaded).
- Adopts the llama-wasm v0.2.8 bridge (attestation-verified release asset) and the llamawasm2go v0.2.5 engine bundle, which also return `llama_ctx_interrupt_addr` / `llama_model_load_progress_addr` as uint64 — a snapshot builder's heap can cross 4GB, where uint32 truncates (SaveState's Go-side JSON decode had the same bug; fixed here. The gemv repack tests' pinned f16 table address follows the released bundle's layout.

## API naming

 (constructor idiom; a function named  would collide with the type) takes a build callback receiving a , whose  records the contexts every fork exposes;  returns an  with those contexts live, fetched by .

## Tests

: fork output is byte-identical to a conventionally prepared instance (greedy, prompt cache hit), a single-threaded (detached) fork still generates, and two live forks generate independently. Full suite passes on darwin/arm64 against the released bundle.

## Depends on

goccy/llama-wasm#14 — released as llama-wasm v0.2.8;  now pins the released llamawasm2go v0.2.5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
EOF
)