### PR TITLE
Add Context.ScoreChoices: batched candidate scoring over the cached stem

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/goccy/go-llama
 
 go 1.25.0
 
-require github.com/goccy/llamawasm2go v0.2.5
+require github.com/goccy/llamawasm2go v0.3.0

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/goccy/llamawasm2go v0.2.5 h1:sHMsNI3OVqZ2UO7MZwF4esBw8Vh3xFCjUX1/3qYZuxU=
-github.com/goccy/llamawasm2go v0.2.5/go.mod h1:2RraXBB/RS2RBlIol/M/rNvIcdtatKWzt8g7q63MPm0=
+github.com/goccy/llamawasm2go v0.3.0 h1:fLjK8JRvbTq+aP4vjRbhxI4Qx90ZG5nfdlR9IXGIAWE=
+github.com/goccy/llamawasm2go v0.3.0/go.mod h1:2RraXBB/RS2RBlIol/M/rNvIcdtatKWzt8g7q63MPm0=

--- a/internal/engine.go
+++ b/internal/engine.go
@@ -44,6 +44,7 @@ const (
 	midCtxNew
 	midCtxReset
 	midCtxScore
+	midCtxScoreChoices
 	midCtxStateLoad
 	midCtxStateSave
 	midDetokenize
@@ -79,21 +80,22 @@ var invokers = [midCount]func(*base.Module, wptr, wptr) (int64, error){
 	midCtxNew:                 wasm2go.Inv_0_10,
 	midCtxReset:               wasm2go.Inv_0_11,
 	midCtxScore:               wasm2go.Inv_0_12,
-	midCtxStateLoad:           wasm2go.Inv_0_13,
-	midCtxStateSave:           wasm2go.Inv_0_14,
-	midDetokenize:             wasm2go.Inv_0_15,
-	midLoraFree:               wasm2go.Inv_0_16,
-	midLoraLoad:               wasm2go.Inv_0_17,
-	midModelFree:              wasm2go.Inv_0_18,
-	midModelInfo:              wasm2go.Inv_0_19,
-	midModelLoad:              wasm2go.Inv_0_20,
-	midModelLoadProgressAddr:  wasm2go.Inv_0_21,
-	midTokenToPiece:           wasm2go.Inv_0_22,
-	midTokenize:               wasm2go.Inv_0_23,
-	midWasmBuildInfo:          wasm2go.Inv_0_24,
-	midWasmFree:               wasm2go.Inv_0_25,
-	midWasmInit:               wasm2go.Inv_0_26,
-	midWasmLastError:          wasm2go.Inv_0_27,
+	midCtxScoreChoices:        wasm2go.Inv_0_13,
+	midCtxStateLoad:           wasm2go.Inv_0_14,
+	midCtxStateSave:           wasm2go.Inv_0_15,
+	midDetokenize:             wasm2go.Inv_0_16,
+	midLoraFree:               wasm2go.Inv_0_17,
+	midLoraLoad:               wasm2go.Inv_0_18,
+	midModelFree:              wasm2go.Inv_0_19,
+	midModelInfo:              wasm2go.Inv_0_20,
+	midModelLoad:              wasm2go.Inv_0_21,
+	midModelLoadProgressAddr:  wasm2go.Inv_0_22,
+	midTokenToPiece:           wasm2go.Inv_0_23,
+	midTokenize:               wasm2go.Inv_0_24,
+	midWasmBuildInfo:          wasm2go.Inv_0_25,
+	midWasmFree:               wasm2go.Inv_0_26,
+	midWasmInit:               wasm2go.Inv_0_27,
+	midWasmLastError:          wasm2go.Inv_0_28,
 }
 
 // NewEngine brings up an independent engine instance: its own wasm module
@@ -445,6 +447,18 @@ func (m *Module) LlamaCtxScore(ctx uint64, text string, textLen uint32) (string,
 	buf = pbAppendString(buf, 2, text)
 	buf = pbAppendUint64(buf, 3, uint64(textLen))
 	resp, err := m.invokeMethod(midCtxScore, buf)
+	if err != nil {
+		return "", err
+	}
+	return readScalarAtField(resp, 1, (*pbReader).readString), nil
+}
+
+func (m *Module) LlamaCtxScoreChoices(ctx uint64, choices string, choicesLen uint32) (string, error) {
+	buf := pbNewBuf()
+	buf = pbAppendUint64(buf, 1, ctx)
+	buf = pbAppendString(buf, 2, choices)
+	buf = pbAppendUint64(buf, 3, uint64(choicesLen))
+	resp, err := m.invokeMethod(midCtxScoreChoices, buf)
 	if err != nil {
 		return "", err
 	}

--- a/internal/gemv_repack_numeric_test.go
+++ b/internal/gemv_repack_numeric_test.go
@@ -26,7 +26,7 @@ import (
 // recorded in the llama-wasm release build log); it moves with any
 // engine rebuild, so re-read it from the log (or the bundle's
 // load32_splat memarg offsets) when bumping the bundle dependency.
-const repackF16Table = 8801136
+const repackF16Table = 8793760
 
 func f16Bits(f float32) uint16 {
 	// Exact for the small power-of-two scales the tests use.

--- a/internal/gemv_repack_numeric_test.go
+++ b/internal/gemv_repack_numeric_test.go
@@ -26,7 +26,7 @@ import (
 // recorded in the llama-wasm release build log); it moves with any
 // engine rebuild, so re-read it from the log (or the bundle's
 // load32_splat memarg offsets) when bumping the bundle dependency.
-const repackF16Table = 8793152
+const repackF16Table = 8801136
 
 func f16Bits(f float32) uint16 {
 	// Exact for the small power-of-two scales the tests use.

--- a/internal/llama.go
+++ b/internal/llama.go
@@ -1212,6 +1212,29 @@ func LlamaCtxScore(ctx uint64, text string, textLen uint32) (string, error) {
 	return readScalarAtField(resp, 1, (*pbReader).readString), nil
 }
 
+// llama_ctx_score_choices scores candidate continuations of the CURRENT
+// cache state: `choices` is a newline-separated list of candidate texts, and
+// for each one the call returns the negative log-likelihood of its tokens as
+// the continuation of what the context has already decoded. Precondition:
+// the caller has just decoded the shared stem (llama_ctx_eval or the prompt
+// phase of generate), so the logits of the next position are live — the
+// first token of every choice is scored from those shared logits, the rest
+// teacher-forced. Each choice's tokens are decoded and then rolled back
+// (llama_memory_seq_rm), so the cache — and prefix-history bookkeeping — end
+// exactly where they started and the choices never see each other. Returns
+// `{"ok":true,"scores":[{"n_tokens":K,"nll":X},...]}` in input order.
+func LlamaCtxScoreChoices(ctx uint64, choices string, choicesLen uint32) (string, error) {
+	buf := pbNewBuf()
+	buf = pbAppendUint64(buf, 1, ctx)
+	buf = pbAppendString(buf, 2, choices)
+	buf = pbAppendUint64(buf, 3, uint64(choicesLen))
+	resp, err := invokeMethod(0, 13, buf, wasm2go.Inv_0_13)
+	if err != nil {
+		return "", err
+	}
+	return readScalarAtField(resp, 1, (*pbReader).readString), nil
+}
+
 // Restore a context state previously produced by llama_ctx_state_save.
 // `data` carries the serialized bytes (the bridge copies them into
 // linear memory; they may contain NUL bytes). A blob from this bridge also
@@ -1223,7 +1246,7 @@ func LlamaCtxStateLoad(ctx uint64, data string, size uint32) (string, error) {
 	buf = pbAppendUint64(buf, 1, ctx)
 	buf = pbAppendString(buf, 2, data)
 	buf = pbAppendUint64(buf, 3, uint64(size))
-	resp, err := invokeMethod(0, 13, buf, wasm2go.Inv_0_13)
+	resp, err := invokeMethod(0, 14, buf, wasm2go.Inv_0_14)
 	if err != nil {
 		return "", err
 	}
@@ -1239,7 +1262,7 @@ func LlamaCtxStateLoad(ctx uint64, data string, size uint32) (string, error) {
 func LlamaCtxStateSave(ctx uint64) (string, error) {
 	buf := pbNewBuf()
 	buf = pbAppendUint64(buf, 1, ctx)
-	resp, err := invokeMethod(0, 14, buf, wasm2go.Inv_0_14)
+	resp, err := invokeMethod(0, 15, buf, wasm2go.Inv_0_15)
 	if err != nil {
 		return "", err
 	}
@@ -1254,7 +1277,7 @@ func LlamaDetokenize(model uint64, tokensJson string, tokensJsonLen uint32, rend
 	buf = pbAppendString(buf, 2, tokensJson)
 	buf = pbAppendUint64(buf, 3, uint64(tokensJsonLen))
 	buf = pbAppendInt32(buf, 4, renderSpecial)
-	resp, err := invokeMethod(0, 15, buf, wasm2go.Inv_0_15)
+	resp, err := invokeMethod(0, 16, buf, wasm2go.Inv_0_16)
 	if err != nil {
 		return "", err
 	}
@@ -1266,7 +1289,7 @@ func LlamaDetokenize(model uint64, tokensJson string, tokensJsonLen uint32, rend
 func LlamaLoraFree(adapter uint64) error {
 	buf := pbNewBuf()
 	buf = pbAppendUint64(buf, 1, adapter)
-	_, err := invokeMethod(0, 16, buf, wasm2go.Inv_0_16)
+	_, err := invokeMethod(0, 17, buf, wasm2go.Inv_0_17)
 	return err
 }
 
@@ -1277,7 +1300,7 @@ func LlamaLoraLoad(model uint64, path string, pathLen uint32) (uint64, error) {
 	buf = pbAppendUint64(buf, 1, model)
 	buf = pbAppendString(buf, 2, path)
 	buf = pbAppendUint64(buf, 3, uint64(pathLen))
-	resp, err := invokeMethod(0, 17, buf, wasm2go.Inv_0_17)
+	resp, err := invokeMethod(0, 18, buf, wasm2go.Inv_0_18)
 	if err != nil {
 		return 0, err
 	}
@@ -1288,7 +1311,7 @@ func LlamaLoraLoad(model uint64, path string, pathLen uint32) (uint64, error) {
 func LlamaModelFree(model uint64) error {
 	buf := pbNewBuf()
 	buf = pbAppendUint64(buf, 1, model)
-	_, err := invokeMethod(0, 18, buf, wasm2go.Inv_0_18)
+	_, err := invokeMethod(0, 19, buf, wasm2go.Inv_0_19)
 	return err
 }
 
@@ -1298,7 +1321,7 @@ func LlamaModelFree(model uint64) error {
 func LlamaModelInfo(model uint64) (string, error) {
 	buf := pbNewBuf()
 	buf = pbAppendUint64(buf, 1, model)
-	resp, err := invokeMethod(0, 19, buf, wasm2go.Inv_0_19)
+	resp, err := invokeMethod(0, 20, buf, wasm2go.Inv_0_20)
 	if err != nil {
 		return "", err
 	}
@@ -1320,7 +1343,7 @@ func LlamaModelLoad(path string, pathLen uint32, nGpuLayers int32, useMmap int32
 	buf = pbAppendUint64(buf, 2, uint64(pathLen))
 	buf = pbAppendInt32(buf, 3, nGpuLayers)
 	buf = pbAppendInt32(buf, 4, useMmap)
-	resp, err := invokeMethod(0, 20, buf, wasm2go.Inv_0_20)
+	resp, err := invokeMethod(0, 21, buf, wasm2go.Inv_0_21)
 	if err != nil {
 		return 0, err
 	}
@@ -1332,7 +1355,7 @@ func LlamaModelLoad(path string, pathLen uint32, nGpuLayers int32, useMmap int32
 // a progress bar. Valid for the lifetime of the wasm instance.
 func LlamaModelLoadProgressAddr() (uint64, error) {
 	buf := pbNewBuf()
-	resp, err := invokeMethod(0, 21, buf, wasm2go.Inv_0_21)
+	resp, err := invokeMethod(0, 22, buf, wasm2go.Inv_0_22)
 	if err != nil {
 		return 0, err
 	}
@@ -1347,7 +1370,7 @@ func LlamaTokenToPiece(model uint64, token int32, renderSpecial int32) (string, 
 	buf = pbAppendUint64(buf, 1, model)
 	buf = pbAppendInt32(buf, 2, token)
 	buf = pbAppendInt32(buf, 3, renderSpecial)
-	resp, err := invokeMethod(0, 22, buf, wasm2go.Inv_0_22)
+	resp, err := invokeMethod(0, 23, buf, wasm2go.Inv_0_23)
 	if err != nil {
 		return "", err
 	}
@@ -1364,7 +1387,7 @@ func LlamaTokenize(model uint64, text string, textLen uint32, addSpecial int32, 
 	buf = pbAppendUint64(buf, 3, uint64(textLen))
 	buf = pbAppendInt32(buf, 4, addSpecial)
 	buf = pbAppendInt32(buf, 5, parseSpecial)
-	resp, err := invokeMethod(0, 23, buf, wasm2go.Inv_0_23)
+	resp, err := invokeMethod(0, 24, buf, wasm2go.Inv_0_24)
 	if err != nil {
 		return "", err
 	}
@@ -1375,7 +1398,7 @@ func LlamaTokenize(model uint64, text string, textLen uint32, addSpecial int32, 
 // and whether this wasm was built with SIMD / threads. Diagnostics only.
 func LlamaWasmBuildInfo() (string, error) {
 	buf := pbNewBuf()
-	resp, err := invokeMethod(0, 24, buf, wasm2go.Inv_0_24)
+	resp, err := invokeMethod(0, 25, buf, wasm2go.Inv_0_25)
 	if err != nil {
 		return "", err
 	}
@@ -1385,7 +1408,7 @@ func LlamaWasmBuildInfo() (string, error) {
 // Free process-wide backend state. After this every handle is invalid.
 func LlamaWasmFree() error {
 	buf := pbNewBuf()
-	_, err := invokeMethod(0, 25, buf, wasm2go.Inv_0_25)
+	_, err := invokeMethod(0, 26, buf, wasm2go.Inv_0_26)
 	return err
 }
 
@@ -1393,7 +1416,7 @@ func LlamaWasmFree() error {
 // llama_model_load, so an embedder normally never calls it.
 func LlamaWasmInit() error {
 	buf := pbNewBuf()
-	_, err := invokeMethod(0, 26, buf, wasm2go.Inv_0_26)
+	_, err := invokeMethod(0, 27, buf, wasm2go.Inv_0_27)
 	return err
 }
 
@@ -1402,7 +1425,7 @@ func LlamaWasmInit() error {
 // this exists for the handle-returning calls, which can only signal 0.
 func LlamaWasmLastError() (string, error) {
 	buf := pbNewBuf()
-	resp, err := invokeMethod(0, 27, buf, wasm2go.Inv_0_27)
+	resp, err := invokeMethod(0, 28, buf, wasm2go.Inv_0_28)
 	if err != nil {
 		return "", err
 	}

--- a/llama.go
+++ b/llama.go
@@ -19,6 +19,7 @@ import (
 	"io"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"sync"
 	"sync/atomic"
 
@@ -202,6 +203,13 @@ type ContextParams struct {
 	// threads-enabled build (BuildInfo.Threads); the single-threaded wasm
 	// clamps to 1.
 	NThreads uint32
+	// NSeqMax is the number of sequences the context can hold at once. A
+	// value > 1 turns on the unified KV cache: NCtx stays the TOTAL cell
+	// budget shared by every sequence, and ScoreChoices batches its
+	// teacher-forced candidates into one decode (one sequence per candidate,
+	// all sharing the stem). Zero or 1 keeps the single-sequence default,
+	// where ScoreChoices decodes candidates one at a time.
+	NSeqMax uint32
 	// Embeddings puts the context in embedding mode, which Context.Embed
 	// requires and which disables generation.
 	Embeddings bool
@@ -219,6 +227,7 @@ type ctxRequest struct {
 	NBatch        uint32  `json:"n_batch,omitempty"`
 	NUBatch       uint32  `json:"n_ubatch,omitempty"`
 	NThreads      uint32  `json:"n_threads,omitempty"`
+	NSeqMax       uint32  `json:"n_seq_max,omitempty"`
 	Embeddings    int     `json:"embeddings,omitempty"`
 	RopeFreqBase  float32 `json:"rope_freq_base,omitempty"`
 	RopeFreqScale float32 `json:"rope_freq_scale,omitempty"`
@@ -537,6 +546,7 @@ func (m *Model) NewContext(p ContextParams) (*Context, error) {
 		NBatch:        p.NBatch,
 		NUBatch:       p.NUBatch,
 		NThreads:      p.NThreads,
+		NSeqMax:       p.NSeqMax,
 		Embeddings:    int(b2i(p.Embeddings)),
 		RopeFreqBase:  p.RopeFreqBase,
 		RopeFreqScale: p.RopeFreqScale,
@@ -789,6 +799,43 @@ func (c *Context) Score(text string) (ScoreResult, error) {
 		return ScoreResult{}, err
 	}
 	return out.ScoreResult, nil
+}
+
+// ScoreChoices scores candidate continuations of the context's CURRENT cache
+// state: for each choice it returns the negative log-likelihood of the
+// choice's tokens as the continuation of what the context has already
+// decoded. Call it right after decoding the shared stem (Eval, or a Generate
+// whose prompt just ran) — the first token of every choice is scored from
+// the live next-position logits, the rest teacher-forced. Each choice is
+// rolled back out of the KV cache before the next, so the choices never see
+// each other and the context ends exactly where it started. Choices must be
+// non-empty and must not contain newlines (the wire format separates them
+// with '\n').
+func (c *Context) ScoreChoices(choices []string) ([]ScoreResult, error) {
+	if err := c.use("score choices"); err != nil {
+		return nil, err
+	}
+	for _, ch := range choices {
+		if ch == "" || strings.ContainsRune(ch, '\n') {
+			return nil, errors.New("llama: score choices: choices must be non-empty and newline-free")
+		}
+	}
+	joined := strings.Join(choices, "\n")
+	js, err := c.model.inst.e().LlamaCtxScoreChoices(c.h, joined, uint32(len(joined)))
+	if err != nil {
+		return nil, err
+	}
+	var out struct {
+		envelope
+		Scores []ScoreResult `json:"scores"`
+	}
+	if err := decode("score choices", js, &out); err != nil {
+		return nil, err
+	}
+	if len(out.Scores) != len(choices) {
+		return nil, fmt.Errorf("llama: score choices: %d scores for %d choices", len(out.Scores), len(choices))
+	}
+	return out.Scores, nil
 }
 
 // generate is the one path into the engine's generation loop. sink is nil for

--- a/scorechoices_test.go
+++ b/scorechoices_test.go
@@ -1,0 +1,199 @@
+package llama_test
+
+import (
+	"math"
+	"testing"
+
+	llama "github.com/goccy/go-llama"
+)
+
+// TestScoreChoices pins the semantics of ScoreChoices: determinism and
+// rollback (repeat calls agree, the stem survives untouched), ranking sanity
+// (a natural continuation outranks gibberish), and — for choices whose
+// tokenization is additive (tokenize(stem+choice) == tokenize(stem) +
+// tokenize(choice)) — exact agreement with the full-decode Score identity
+// Score(stem+choice) - Score(stem). Additivity fails wholesale under a
+// SentencePiece vocabulary with a dummy space prefix (the test model), where
+// the standalone tokenization carries a leading artifact token; ScoreChoices
+// always scores the standalone tokenization, which keeps every choice on an
+// equal footing, so the exact check runs only where the identity is defined.
+func TestScoreChoices(t *testing.T) {
+	m := load(t)
+	defer m.Close()
+
+	const stem = "Once upon a time, in a land far away, there lived a"
+	choices := []string{" little girl", " zzz qqq xxw", " dragon"}
+
+	ctx, err := m.NewContext(llama.ContextParams{NCtx: 256})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ctx.Close()
+	if _, err := ctx.Eval(stem, true, true); err != nil {
+		t.Fatal(err)
+	}
+	got, err := ctx.ScoreChoices(choices)
+	if err != nil {
+		t.Fatalf("ScoreChoices: %v", err)
+	}
+
+	// Ranking sanity: per-token NLL of the natural continuation beats the
+	// gibberish one.
+	nat := got[0].NLL / float64(got[0].NTokens)
+	gib := got[1].NLL / float64(got[1].NTokens)
+	if nat >= gib {
+		t.Errorf("natural continuation per-token NLL %v not better than gibberish %v", nat, gib)
+	}
+
+	// Repeatable: each choice is rolled back, so a second call agrees bit
+	// for bit — including when the choices arrive in a different order.
+	again, err := ctx.ScoreChoices(choices)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := range choices {
+		if got[i].NLL != again[i].NLL {
+			t.Errorf("choice %d: NLL changed across calls: %v then %v", i, got[i].NLL, again[i].NLL)
+		}
+	}
+	rev := []string{choices[2], choices[1], choices[0]}
+	revScores, err := ctx.ScoreChoices(rev)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if revScores[2].NLL != got[0].NLL || revScores[0].NLL != got[2].NLL {
+		t.Error("scores depend on choice order")
+	}
+
+	// The cache still holds exactly the stem: generating from it matches a
+	// fresh context's generation over the same prompt.
+	res, err := ctx.Generate(stem, llama.Params{NPredict: 6, CachePrompt: true, Temperature: 0})
+	if err != nil {
+		t.Fatal(err)
+	}
+	fctx, err := m.NewContext(llama.ContextParams{NCtx: 256})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer fctx.Close()
+	want, err := fctx.Generate(stem, llama.Params{NPredict: 6, Temperature: 0})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Text != want.Text {
+		t.Errorf("generation after ScoreChoices = %q, fresh context = %q", res.Text, want.Text)
+	}
+	if res.NCached == 0 {
+		t.Error("stem was not cached after ScoreChoices rollback")
+	}
+
+	// Exact identity against the full-decode Score, where defined.
+	stemToks, err := m.Tokenize(stem, true, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rctx, err := m.NewContext(llama.ContextParams{NCtx: 256})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rctx.Close()
+	stemScore, err := rctx.Score(stem)
+	if err != nil {
+		t.Fatal(err)
+	}
+	checked := 0
+	for i, ch := range choices {
+		cToks, err := m.Tokenize(ch, false, true)
+		if err != nil {
+			t.Fatal(err)
+		}
+		fullToks, err := m.Tokenize(stem+ch, true, true)
+		if err != nil {
+			t.Fatal(err)
+		}
+		additive := len(fullToks) == len(stemToks)+len(cToks)
+		for j := 0; additive && j < len(cToks); j++ {
+			additive = fullToks[len(stemToks)+j] == cToks[j]
+		}
+		if !additive {
+			continue
+		}
+		full, err := rctx.Score(stem + ch)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if d := math.Abs(got[i].NLL - (full.NLL - stemScore.NLL)); d > 1e-3 {
+			t.Errorf("choice %d: NLL = %v, full-decode reference %v (diff %v)", i, got[i].NLL, full.NLL-stemScore.NLL, d)
+		}
+		checked++
+	}
+	t.Logf("exact identity checked on %d/%d choices (rest non-additive under this vocabulary)", checked, len(choices))
+
+	// Input validation.
+	if _, err := ctx.ScoreChoices([]string{"ok", "bad\nline"}); err == nil {
+		t.Error("newline choice accepted")
+	}
+	if _, err := ctx.ScoreChoices([]string{""}); err == nil {
+		t.Error("empty choice accepted")
+	}
+}
+
+// TestScoreChoicesSeqBatched pins that the multi-sequence batched path
+// (NSeqMax > 1: one decode for all candidates, each on its own sequence
+// sharing the stem) returns bit-identical scores to the single-sequence
+// sequential path, over enough choices to also exercise group chunking.
+func TestScoreChoicesSeqBatched(t *testing.T) {
+	m := load(t)
+	defer m.Close()
+
+	const stem = "Once upon a time, in a land far away, there lived a"
+	choices := []string{
+		" little girl", " dragon", " brave knight of the realm", " cat",
+		" wise old man", " tiny mouse in a big house", " king", " queen of the north",
+	}
+
+	seq, err := m.NewContext(llama.ContextParams{NCtx: 256})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer seq.Close()
+	if _, err := seq.Eval(stem, true, true); err != nil {
+		t.Fatal(err)
+	}
+	want, err := seq.ScoreChoices(choices)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// NSeqMax 4 forces chunking (8 multi-token candidates over 3 spare
+	// sequences per group).
+	bat, err := m.NewContext(llama.ContextParams{NCtx: 256, NSeqMax: 4})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer bat.Close()
+	if _, err := bat.Eval(stem, true, true); err != nil {
+		t.Fatal(err)
+	}
+	got, err := bat.ScoreChoices(choices)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := range choices {
+		if got[i].NTokens != want[i].NTokens {
+			t.Errorf("choice %d: NTokens %d vs %d", i, got[i].NTokens, want[i].NTokens)
+		}
+		if d := math.Abs(got[i].NLL - want[i].NLL); d > 1e-4 {
+			t.Errorf("choice %d: batched NLL %v vs sequential %v (diff %v)", i, got[i].NLL, want[i].NLL, d)
+		}
+	}
+
+	// The batched context still generates from the untouched stem.
+	res, err := bat.Generate(stem, llama.Params{NPredict: 4, CachePrompt: true, Temperature: 0})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.NCached == 0 {
+		t.Error("stem not cached after batched ScoreChoices")
+	}
+}


### PR DESCRIPTION
Companion to goccy/llama-wasm#15 (+ the #16 hardening): score N candidate continuations of one prompt while paying for the shared stem once. Builds against the released llamawasm2go v0.3.0.

```go
ctx.Eval(stem, true, true)                       // decode the stem once
scores, _ := ctx.ScoreChoices([]string{"yes", "no", "maybe"})
// scores[i].NLL = -log P(choice_i | stem), teacher-forced, exact
```

## Semantics

- Each candidate is scored as the continuation of the context's current cache state; candidates are rolled back between scores, so they never see each other and the context ends exactly where it started — generation from the stem afterwards is unaffected (pinned by test).
- The stem's next-position logits are regenerated deterministically inside the engine (from the prefix history), so results do not depend on which decode ran last; repeat calls are bit-identical.
- Candidates score their standalone tokenization, which keeps them on an equal footing. Where tokenization is additive, the result equals the full-decode identity `Score(stem+choice) - Score(stem)` exactly (pinned by test; a SentencePiece dummy space prefix breaks additivity wholesale, which the test documents).

## Batched path

`ContextParams.NSeqMax` > 1 turns on the engine's unified KV cache — `NCtx` stays the TOTAL cell budget, so no extra cache memory — and all candidates batch into one decode, each on its own sequence sharing the stem's cells. The per-decode fixed cost (threadpool wake, graph launch) is paid once instead of once per candidate. `TestScoreChoicesSeqBatched` pins bit-identical scores between the sequential and batched paths, including group chunking.

## Bundle adoption

`go.mod` requires the released llamawasm2go v0.3.0 (no replace). The gemv repack tests' pinned f16 table address follows this bundle's layout (8793760), located empirically by scanning an initialized engine's linear memory for the table's leading f16 values. Full suite passes against the released bundle.