### PR TITLE
perf: measure the amd64 gap against native llama.cpp

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -27,6 +27,10 @@ on:
         description: "iterations for the pp benchmark"
         required: false
         default: "6"
+      model_url:
+        description: "Q8_0 GGUF to benchmark (blank = qwen2.5-0.5b)"
+        required: false
+        default: ""
 
 permissions:
   contents: read
@@ -89,9 +93,13 @@ jobs:
           echo "llamawasm2go now:"; go list -m github.com/goccy/llamawasm2go
 
       - name: Fetch Q8_0 model
+        env:
+          MODEL_URL_OVERRIDE: ${{ inputs.model_url }}
         run: |
+          url="${MODEL_URL_OVERRIDE:-$MODEL_URL}"
+          echo "model: $url"
           mkdir -p testdata
-          curl -fSL --proto '=https' --tlsv1.2 -o "$MODEL_PATH" "$MODEL_URL"
+          curl -fSL --proto '=https' --tlsv1.2 -o "$MODEL_PATH" "$url"
           ls -la "$MODEL_PATH"
 
       # The comparison target: llama.cpp built natively on this very

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,0 +1,235 @@
+name: Bench
+
+# On-demand throughput benchmark for the amd64 native-gap work: it reports
+# token-generation (tg) and prompt-processing (pp) tok/s for a Q8_0 model,
+# for go-llama AND for a native llama.cpp build ON THE SAME RUNNER, so the
+# honest cost of running fully in Go can be read off directly. It also
+# prints each runner's CPU SIMD capabilities and a CPU profile with a
+# per-instruction disassembly of the hot kernel, which is what drives the
+# kernel work. Trigger with:
+#   gh workflow run bench.yml -f llamawasm2go_ref=<branch-or-version>
+# It also runs automatically on every push to a perf/** branch, benchmarking
+# whatever llamawasm2go the branch's go.mod pins — that is the dev loop.
+on:
+  push:
+    branches: ["perf/**"]
+  workflow_dispatch:
+    inputs:
+      llamawasm2go_ref:
+        description: "llamawasm2go module version or branch to benchmark (blank = go.mod pin)"
+        required: false
+        default: ""
+      decode_tokens:
+        description: "tokens to decode for the tg benchmark"
+        required: false
+        default: "48"
+      prompt_reps:
+        description: "iterations for the pp benchmark"
+        required: false
+        default: "6"
+
+permissions:
+  contents: read
+
+env:
+  # The Q8_0 model whose vec_dot kernel the SIMD work targets. Small enough to
+  # fetch per run, quantized so it exercises the integer dot path.
+  MODEL_URL: https://huggingface.co/Qwen/Qwen2.5-0.5B-Instruct-GGUF/resolve/main/qwen2.5-0.5b-instruct-q8_0.gguf
+  MODEL_PATH: testdata/qwen2.5-0.5b-instruct-q8_0.gguf
+
+jobs:
+  bench:
+    name: Bench (${{ matrix.name }})
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: amd64
+            runner: ubuntu-latest
+            goamd64: v2
+          - name: arm64
+            runner: ubuntu-24.04-arm
+            goamd64: ""
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: CPU capabilities
+        run: |
+          echo "=== uname ==="; uname -m
+          echo "=== page size / THP ==="
+          getconf PAGESIZE
+          cat /sys/kernel/mm/transparent_hugepage/enabled 2>/dev/null || true
+          echo "=== lscpu ==="; lscpu || true
+          echo "=== SIMD flags ==="
+          if [ "$(uname -m)" = "x86_64" ]; then
+            grep -om1 -E 'flags.*' /proc/cpuinfo | tr ' ' '\n' \
+              | grep -E '^(sse4_2|avx|avx2|f16c|fma|avx512f|avx512bw|avx512vl|avx512_vnni|avx512vnni|avx_vnni|amx_int8)$' | sort -u \
+              | sed 's/^/  have: /' || true
+          else
+            grep -om1 -E 'Features.*' /proc/cpuinfo | tr ' ' '\n' \
+              | grep -E '^(asimd|asimddp|i8mm|sve|sve2|bf16)$' | sort -u \
+              | sed 's/^/  have: /' || true
+          fi
+
+      - name: Point at a llamawasm2go ref
+        if: ${{ inputs.llamawasm2go_ref != '' }}
+        run: |
+          go get github.com/goccy/llamawasm2go@${{ inputs.llamawasm2go_ref }}
+          go mod tidy
+          echo "llamawasm2go now:"; go list -m github.com/goccy/llamawasm2go
+
+      - name: Fetch Q8_0 model
+        run: |
+          mkdir -p testdata
+          curl -fSL --proto '=https' --tlsv1.2 -o "$MODEL_PATH" "$MODEL_URL"
+          ls -la "$MODEL_PATH"
+
+      # The comparison target: llama.cpp built natively on this very
+      # runner (-march=native equivalent via GGML_NATIVE), CPU backend
+      # only. The commit is printed so drift between runs is visible.
+      - name: Build native llama.cpp
+        timeout-minutes: 25
+        run: |
+          git clone --depth 1 https://github.com/ggml-org/llama.cpp /tmp/llama.cpp
+          cd /tmp/llama.cpp
+          echo "llama.cpp commit: $(git rev-parse HEAD)"
+          cmake -B build -DCMAKE_BUILD_TYPE=Release -DGGML_NATIVE=ON \
+            -DLLAMA_CURL=OFF >/dev/null
+          cmake --build build --target llama-bench -j "$(nproc)" 2>&1 | tail -3
+          ls -la build/bin/llama-bench
+
+      # Native throughput on the same runner and model. -t 1 matches the
+      # engine's single-threaded execution (the kernel-efficiency
+      # comparison); -t nproc shows the full-machine native ceiling.
+      - name: Native llama-bench (same runner)
+        timeout-minutes: 20
+        run: |
+          BENCH=/tmp/llama.cpp/build/bin/llama-bench
+          echo "### native llama.cpp, 1 thread ###"
+          "$BENCH" -m "$MODEL_PATH" -p 512 -n 64 -t 1 -r 2 2>/dev/null | tee native-t1.txt
+          echo "### native llama.cpp, $(nproc) threads ###"
+          "$BENCH" -m "$MODEL_PATH" -p 512 -n 64 -t "$(nproc)" -r 2 2>/dev/null | tee native-tn.txt
+
+      # A 4-token decode with a tight timeout: on a pathological
+      # runner/bundle combination this fails in seconds with the CPU
+      # model already printed, instead of wedging the long benches.
+      - name: Quick probe (4 tokens)
+        timeout-minutes: 8
+        env:
+          GOAMD64: ${{ matrix.goamd64 }}
+          GO_LLAMA_TEST_MODEL: ${{ github.workspace }}/${{ env.MODEL_PATH }}
+        run: |
+          go test -run=NONE -bench='BenchmarkDecode$' -benchtime=4x -count=1 -timeout=7m .
+
+      # Greedy text of a fixed prompt: the fast-math tile kernels are
+      # not bit-exact vs wasm, so cross-check token-level equivalence by
+      # comparing this text across runners (arm64's kernel is the
+      # long-validated reference).
+      - name: Greedy text probe
+        timeout-minutes: 10
+        env:
+          GOAMD64: ${{ matrix.goamd64 }}
+          GO_LLAMA_TEST_MODEL: ${{ github.workspace }}/${{ env.MODEL_PATH }}
+        run: |
+          set -o pipefail
+          mkdir -p /tmp/textprobe && cat > /tmp/textprobe/main_test.go <<'GO'
+          package llama_test
+
+          import (
+          	"fmt"
+          	"os"
+          	"path/filepath"
+          	"testing"
+
+          	llama "github.com/goccy/go-llama"
+          )
+
+          func TestGreedyText(t *testing.T) {
+          	model := os.Getenv("GO_LLAMA_TEST_MODEL")
+          	inst, err := llama.New(llama.WithPreopenDir(filepath.Dir(model)))
+          	if err != nil {
+          		t.Fatal(err)
+          	}
+          	m, err := inst.LoadModel(filepath.Base(model))
+          	if err != nil {
+          		t.Fatal(err)
+          	}
+          	ctx, err := m.NewContext(llama.ContextParams{NCtx: 256})
+          	if err != nil {
+          		t.Fatal(err)
+          	}
+          	res, err := ctx.Generate("The quick brown fox", llama.Params{NPredict: 24, Temperature: 0})
+          	if err != nil {
+          		t.Fatal(err)
+          	}
+          	fmt.Printf("GREEDY24: %q\n", res.Text)
+          }
+          GO
+          cp /tmp/textprobe/main_test.go ./greedy_probe_test.go
+          go test -run TestGreedyText -v -count=1 . | grep -E "GREEDY24|FAIL|ok "
+          rm -f ./greedy_probe_test.go
+
+      - name: Benchmark (go-llama)
+        timeout-minutes: 30
+        env:
+          GOAMD64: ${{ matrix.goamd64 }}
+          GO_LLAMA_TEST_MODEL: ${{ github.workspace }}/${{ env.MODEL_PATH }}
+        run: |
+          echo "### go-llama engine: $(go list -m github.com/goccy/llamawasm2go) ###"
+          go test -run=NONE -bench='BenchmarkDecode$' \
+            -benchtime=${{ inputs.decode_tokens || '48' }}x -count=2 -timeout=30m . | tee tg.txt
+          go test -run=NONE -bench='BenchmarkPromptEval$' \
+            -benchtime=${{ inputs.prompt_reps || '6' }}x -count=1 -timeout=30m . | tee pp.txt
+
+      - name: CPU profile (decode)
+        timeout-minutes: 30
+        env:
+          GOAMD64: ${{ matrix.goamd64 }}
+          GO_LLAMA_TEST_MODEL: ${{ github.workspace }}/${{ env.MODEL_PATH }}
+        run: |
+          go test -run=NONE -bench='BenchmarkDecode$' \
+            -benchtime=${{ inputs.decode_tokens || '48' }}x -count=1 -timeout=30m \
+            -cpuprofile=cpu.prof .
+          echo "### tg top-30 flat ###"
+          go tool pprof -top -nodecount=30 go-llama.test cpu.prof
+          echo "### tg top-15 cumulative ###"
+          go tool pprof -top -cum -nodecount=15 go-llama.test cpu.prof
+          echo "### tg hot-kernel disasm (per-instruction cycles) ###"
+          KERN=$(go tool pprof -top -nodecount=1 go-llama.test cpu.prof | awk 'END{print $NF}')
+          go tool pprof -disasm "$KERN" go-llama.test cpu.prof 2>/dev/null | awk '$1 != "." && $1 != "" {print}' | head -120
+
+      - name: CPU profile (prompt)
+        timeout-minutes: 60
+        env:
+          GOAMD64: ${{ matrix.goamd64 }}
+          GO_LLAMA_TEST_MODEL: ${{ github.workspace }}/${{ env.MODEL_PATH }}
+        run: |
+          go test -run=NONE -bench='BenchmarkPromptEval$' \
+            -benchtime=2x -count=1 -timeout=60m \
+            -cpuprofile=pp.prof .
+          echo "### pp top-20 flat ###"
+          go tool pprof -top -nodecount=20 go-llama.test pp.prof
+          echo "### pp hot-kernel disasm ###"
+          KERN=$(go tool pprof -top -nodecount=1 go-llama.test pp.prof | awk 'END{print $NF}')
+          go tool pprof -disasm "$KERN" go-llama.test pp.prof 2>/dev/null | awk '$1 != "." && $1 != "" {print}' | sort -k1 -rh | head -40
+
+      - name: Summary
+        if: always()
+        run: |
+          {
+            echo "## ${{ matrix.name }}";
+            echo '```';
+            echo "go-llama ($(go list -m github.com/goccy/llamawasm2go 2>/dev/null)):";
+            grep -hE 'tok/s|prompt_tok/s' tg.txt pp.txt 2>/dev/null || echo "(no results)";
+            echo;
+            echo "native llama.cpp, 1 thread (same runner):";
+            grep -hE 'pp512|tg64' native-t1.txt 2>/dev/null || echo "(no results)";
+            echo;
+            echo "native llama.cpp, all threads (same runner):";
+            grep -hE 'pp512|tg64' native-tn.txt 2>/dev/null || echo "(no results)";
+            echo '```';
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -31,6 +31,12 @@ on:
 permissions:
   contents: read
 
+# Iteration pushes supersede each other: only the newest bench per
+# branch matters, so cancel the stale one.
+concurrency:
+  group: bench-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   # The Q8_0 model whose vec_dot kernel the SIMD work targets. Small enough to
   # fetch per run, quantized so it exercises the integer dot path.
@@ -170,7 +176,7 @@ jobs:
           }
           GO
           cp /tmp/textprobe/main_test.go ./greedy_probe_test.go
-          go test -run TestGreedyText -v -count=1 . | grep -E "GREEDY24|FAIL|ok "
+          go test -run TestGreedyText -v -count=1 . | grep -E "GREEDY24|FAIL|ok " | tee greedy.txt
           rm -f ./greedy_probe_test.go
 
       - name: Benchmark (go-llama)
@@ -185,6 +191,30 @@ jobs:
           go test -run=NONE -bench='BenchmarkPromptEval$' \
             -benchtime=${{ inputs.prompt_reps || '6' }}x -count=1 -timeout=30m . | tee pp.txt
 
+      # Same-runner A/B: the pool mixes CPU generations (Zen 3 / Zen 4 /
+      # several Intels, ~30%+ apart), so only a delta measured on THIS
+      # runner is meaningful. The baseline is the v0.3.0 release engine.
+      - name: Benchmark (v0.3.0 baseline, same runner)
+        timeout-minutes: 60
+        env:
+          GOAMD64: ${{ matrix.goamd64 }}
+          GO_LLAMA_TEST_MODEL: ${{ github.workspace }}/${{ env.MODEL_PATH }}
+          GOFLAGS: -mod=mod
+        run: |
+          go get github.com/goccy/llamawasm2go@v0.3.0
+          go mod tidy
+          echo "### baseline: $(go list -m github.com/goccy/llamawasm2go) ###"
+          go test -run=NONE -bench='BenchmarkDecode$' \
+            -benchtime=${{ inputs.decode_tokens || '48' }}x -count=2 -timeout=30m . | tee tg-base.txt
+          go test -run=NONE -bench='BenchmarkPromptEval$' \
+            -benchtime=3x -count=1 -timeout=55m . | tee pp-base.txt
+          git checkout -- go.mod go.sum
+
+      # The profile runs keep the compiled test binary (-o): together
+      # with the raw .prof files in the run artifact it lets ANY
+      # function be pprof-disasm'd/-list'ed locally after `gh run
+      # download`, so one CI run answers every profiling question of
+      # the iteration — the logs below only carry the highlights.
       - name: CPU profile (decode)
         timeout-minutes: 30
         env:
@@ -193,7 +223,7 @@ jobs:
         run: |
           go test -run=NONE -bench='BenchmarkDecode$' \
             -benchtime=${{ inputs.decode_tokens || '48' }}x -count=1 -timeout=30m \
-            -cpuprofile=cpu.prof .
+            -cpuprofile=cpu.prof -o go-llama.test .
           echo "### tg top-30 flat ###"
           go tool pprof -top -nodecount=30 go-llama.test cpu.prof
           echo "### tg top-15 cumulative ###"
@@ -210,12 +240,34 @@ jobs:
         run: |
           go test -run=NONE -bench='BenchmarkPromptEval$' \
             -benchtime=2x -count=1 -timeout=60m \
-            -cpuprofile=pp.prof .
+            -cpuprofile=pp.prof -o go-llama.test .
           echo "### pp top-20 flat ###"
           go tool pprof -top -nodecount=20 go-llama.test pp.prof
           echo "### pp hot-kernel disasm ###"
           KERN=$(go tool pprof -top -nodecount=1 go-llama.test pp.prof | awk 'END{print $NF}')
           go tool pprof -disasm "$KERN" go-llama.test pp.prof 2>/dev/null | awk '$1 != "." && $1 != "" {print}' | sort -k1 -rh | head -40
+
+      # Everything an offline analysis needs, per matrix arch:
+      #   gh run download <run-id> -n bench-<arch>
+      #   go tool pprof -disasm <Fn> go-llama.test cpu.prof
+      - name: Upload profiles and outputs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: bench-${{ matrix.name }}
+          if-no-files-found: ignore
+          retention-days: 14
+          path: |
+            cpu.prof
+            pp.prof
+            go-llama.test
+            tg.txt
+            pp.txt
+            native-t1.txt
+            native-tn.txt
+            greedy.txt
+            tg-base.txt
+            pp-base.txt
 
       - name: Summary
         if: always()
@@ -225,6 +277,9 @@ jobs:
             echo '```';
             echo "go-llama ($(go list -m github.com/goccy/llamawasm2go 2>/dev/null)):";
             grep -hE 'tok/s|prompt_tok/s' tg.txt pp.txt 2>/dev/null || echo "(no results)";
+            echo;
+            echo "baseline v0.3.0 (same runner):";
+            grep -hE 'tok/s|prompt_tok/s' tg-base.txt pp-base.txt 2>/dev/null || echo "(no results)";
             echo;
             echo "native llama.cpp, 1 thread (same runner):";
             grep -hE 'pp512|tg64' native-t1.txt 2>/dev/null || echo "(no results)";

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -199,6 +199,80 @@ jobs:
           go test -run=NONE -bench='BenchmarkPromptEval$' \
             -benchtime=${{ inputs.prompt_reps || '6' }}x -count=1 -timeout=30m . | tee pp.txt
 
+      - name: Engine feature detection
+        env:
+          GOAMD64: ${{ matrix.goamd64 }}
+        run: |
+          mkdir -p featprobe
+          cat > featprobe/main_amd64.go <<'EOF2'
+          package main
+
+          import (
+          	"fmt"
+
+          	"github.com/goccy/llamawasm2go/base"
+          )
+
+          func cpuid(eax, ecx uint32) (a, b, c, d uint32)
+          func xgetbv() (lo, hi uint32)
+
+          func main() {
+          	_, b7, c7, _ := cpuid(7, 0)
+          	_, _, c1, _ := cpuid(1, 0)
+          	lo, hi := xgetbv()
+          	fmt.Printf("FEATPROBE HasAVX2=%v HasAVX512VNNI=%v cpuid1.ecx=%#x cpuid7.ebx=%#x cpuid7.ecx=%#x xcr0=%#x:%#x\n",
+          		base.HasAVX2, base.HasAVX512VNNI, c1, b7, c7, hi, lo)
+          }
+          EOF2
+          cat > featprobe/cpuid_amd64.s <<'EOF2'
+          #include "textflag.h"
+          TEXT ·cpuid(SB), NOSPLIT, $0-24
+          	MOVL eax+0(FP), AX
+          	MOVL ecx+4(FP), CX
+          	CPUID
+          	MOVL AX, a+8(FP)
+          	MOVL BX, b+12(FP)
+          	MOVL CX, c+16(FP)
+          	MOVL DX, d+20(FP)
+          	RET
+          TEXT ·xgetbv(SB), NOSPLIT, $0-8
+          	MOVL $0, CX
+          	XGETBV
+          	MOVL AX, lo+0(FP)
+          	MOVL DX, hi+4(FP)
+          	RET
+          EOF2
+          cat > featprobe/main_arm64.go <<'EOF2'
+          package main
+
+          import (
+          	"fmt"
+
+          	"github.com/goccy/llamawasm2go/base"
+          )
+
+          func main() {
+          	fmt.Printf("FEATPROBE CPUDotProd=%v CPUI8MM=%v\n", base.CPUDotProd, base.CPUI8MM)
+          }
+          EOF2
+          go run ./featprobe || true
+          rm -rf featprobe
+
+      - name: CPU profile (go-llama)
+        timeout-minutes: 30
+        env:
+          GOAMD64: ${{ matrix.goamd64 }}
+          GO_LLAMA_TEST_MODEL: ${{ github.workspace }}/${{ env.MODEL_PATH }}
+        run: |
+          go test -run=NONE -bench='BenchmarkDecode$' -benchtime=64x -count=1 \
+            -cpuprofile tg.prof -timeout=30m . > /dev/null
+          echo "### decode profile ###"
+          go tool pprof -top -nodecount=16 go-llama.test tg.prof 2>/dev/null | tail -n +5
+          go test -run=NONE -bench='BenchmarkPromptEval$' -benchtime=3x -count=1 \
+            -cpuprofile pp.prof -timeout=30m . > /dev/null
+          echo "### prompt profile ###"
+          go tool pprof -top -nodecount=16 go-llama.test pp.prof 2>/dev/null | tail -n +5
+
       # Same-runner A/B: the pool mixes CPU generations (Zen 3 / Zen 4 /
       # several Intels, ~30%+ apart), so only a delta measured on THIS
       # runner is meaningful. The baseline is the v0.3.0 release engine.

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/goccy/go-llama
 
 go 1.25.0
 
-require github.com/goccy/llamawasm2go v0.3.3-0.20260903100604-7c603a955172
+require github.com/goccy/llamawasm2go v0.3.3-0.20260903141834-9788596dc7a3

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/goccy/go-llama
 
 go 1.25.0
 
-require github.com/goccy/llamawasm2go v0.2.6-0.20260902051004-e32be00f16dc
+require github.com/goccy/llamawasm2go v0.2.6-0.20260902062907-fc0ce95bcb7b

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/goccy/go-llama
 
 go 1.25.0
 
-require github.com/goccy/llamawasm2go v0.3.3-0.20260903141834-9788596dc7a3
+require github.com/goccy/llamawasm2go v0.3.3-0.20260903145215-57d0e6fbfeb9

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/goccy/go-llama
 
 go 1.25.0
 
-require github.com/goccy/llamawasm2go v0.2.6-0.20260902033239-7dec39dd45a6
+require github.com/goccy/llamawasm2go v0.2.6-0.20260902043553-8b00acde598c

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/goccy/go-llama
 
 go 1.25.0
 
-require github.com/goccy/llamawasm2go v0.3.3-0.20260903093610-c1a9cb1cb791
+require github.com/goccy/llamawasm2go v0.3.3-0.20260903095331-eed7bbb0e222

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/goccy/go-llama
 
 go 1.25.0
 
-require github.com/goccy/llamawasm2go v0.3.3-0.20260903095331-eed7bbb0e222
+require github.com/goccy/llamawasm2go v0.3.3-0.20260903100604-7c603a955172

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/goccy/go-llama
 
 go 1.25.0
 
-require github.com/goccy/llamawasm2go v0.2.6-0.20260902043553-8b00acde598c
+require github.com/goccy/llamawasm2go v0.2.6-0.20260902051004-e32be00f16dc

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/goccy/go-llama
 
 go 1.25.0
 
-require github.com/goccy/llamawasm2go v0.3.0
+require github.com/goccy/llamawasm2go v0.2.6-0.20260902024102-cd32b8f1c105

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/goccy/go-llama
 
 go 1.25.0
 
-require github.com/goccy/llamawasm2go v0.2.6-0.20260902062907-fc0ce95bcb7b
+require github.com/goccy/llamawasm2go v0.2.6-0.20260902071540-c9d549fc3e97

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/goccy/go-llama
 
 go 1.25.0
 
-require github.com/goccy/llamawasm2go v0.2.6-0.20260902071540-c9d549fc3e97
+require github.com/goccy/llamawasm2go v0.3.3-0.20260903074734-86d4a6a3ef9f

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/goccy/go-llama
 
 go 1.25.0
 
-require github.com/goccy/llamawasm2go v0.2.6-0.20260902024102-cd32b8f1c105
+require github.com/goccy/llamawasm2go v0.2.6-0.20260902033239-7dec39dd45a6

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/goccy/go-llama
 
 go 1.25.0
 
-require github.com/goccy/llamawasm2go v0.3.3-0.20260903074734-86d4a6a3ef9f
+require github.com/goccy/llamawasm2go v0.3.3-0.20260903093610-c1a9cb1cb791

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/goccy/llamawasm2go v0.3.3-0.20260903141834-9788596dc7a3 h1:CRL7/TI3WyJLDM8i1mxdOee4rzTmIphFe6FSY9HVl5E=
-github.com/goccy/llamawasm2go v0.3.3-0.20260903141834-9788596dc7a3/go.mod h1:2RraXBB/RS2RBlIol/M/rNvIcdtatKWzt8g7q63MPm0=
+github.com/goccy/llamawasm2go v0.3.3-0.20260903145215-57d0e6fbfeb9 h1:Da5WaXipikg+lfMTlcjw0oi/KJvwwQeEm8Fe2RgHh6Q=
+github.com/goccy/llamawasm2go v0.3.3-0.20260903145215-57d0e6fbfeb9/go.mod h1:2RraXBB/RS2RBlIol/M/rNvIcdtatKWzt8g7q63MPm0=

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/goccy/llamawasm2go v0.2.6-0.20260902043553-8b00acde598c h1:JLJHMu6nVi+TxgJ53WTY1HqIB+R8ny/gE1zRjFZRVs4=
-github.com/goccy/llamawasm2go v0.2.6-0.20260902043553-8b00acde598c/go.mod h1:2RraXBB/RS2RBlIol/M/rNvIcdtatKWzt8g7q63MPm0=
+github.com/goccy/llamawasm2go v0.2.6-0.20260902051004-e32be00f16dc h1:MkXojyTDPY/dY7MVHrz0o/1Cudc20Gzs8fNYwkDVE+c=
+github.com/goccy/llamawasm2go v0.2.6-0.20260902051004-e32be00f16dc/go.mod h1:2RraXBB/RS2RBlIol/M/rNvIcdtatKWzt8g7q63MPm0=

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/goccy/llamawasm2go v0.3.0 h1:fLjK8JRvbTq+aP4vjRbhxI4Qx90ZG5nfdlR9IXGIAWE=
-github.com/goccy/llamawasm2go v0.3.0/go.mod h1:2RraXBB/RS2RBlIol/M/rNvIcdtatKWzt8g7q63MPm0=
+github.com/goccy/llamawasm2go v0.2.6-0.20260902024102-cd32b8f1c105 h1:jJN1cMZ+ZLbHmOD422kKHap/TRBR1e0m2cU8IRm6uJo=
+github.com/goccy/llamawasm2go v0.2.6-0.20260902024102-cd32b8f1c105/go.mod h1:2RraXBB/RS2RBlIol/M/rNvIcdtatKWzt8g7q63MPm0=

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/goccy/llamawasm2go v0.2.6-0.20260902071540-c9d549fc3e97 h1:/rNLmYGECXWGGEIKTLCjMgZ/ncR19TTh0cCqUdASVi0=
-github.com/goccy/llamawasm2go v0.2.6-0.20260902071540-c9d549fc3e97/go.mod h1:2RraXBB/RS2RBlIol/M/rNvIcdtatKWzt8g7q63MPm0=
+github.com/goccy/llamawasm2go v0.3.3-0.20260903074734-86d4a6a3ef9f h1:rS7eLnni9hYDOa1gBeu2+z6kZtjtg5monAYehAVx3Do=
+github.com/goccy/llamawasm2go v0.3.3-0.20260903074734-86d4a6a3ef9f/go.mod h1:2RraXBB/RS2RBlIol/M/rNvIcdtatKWzt8g7q63MPm0=

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/goccy/llamawasm2go v0.3.3-0.20260903095331-eed7bbb0e222 h1:qDqdXMe3/TvyMtsNmtRwdauo3F9qUOaLJ4WMAgc6SxE=
-github.com/goccy/llamawasm2go v0.3.3-0.20260903095331-eed7bbb0e222/go.mod h1:2RraXBB/RS2RBlIol/M/rNvIcdtatKWzt8g7q63MPm0=
+github.com/goccy/llamawasm2go v0.3.3-0.20260903100604-7c603a955172 h1:J0ZtombA0+JiSd5ev1rNYI/7gEsEYq6CatQks3j6MDc=
+github.com/goccy/llamawasm2go v0.3.3-0.20260903100604-7c603a955172/go.mod h1:2RraXBB/RS2RBlIol/M/rNvIcdtatKWzt8g7q63MPm0=

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/goccy/llamawasm2go v0.2.6-0.20260902024102-cd32b8f1c105 h1:jJN1cMZ+ZLbHmOD422kKHap/TRBR1e0m2cU8IRm6uJo=
-github.com/goccy/llamawasm2go v0.2.6-0.20260902024102-cd32b8f1c105/go.mod h1:2RraXBB/RS2RBlIol/M/rNvIcdtatKWzt8g7q63MPm0=
+github.com/goccy/llamawasm2go v0.2.6-0.20260902033239-7dec39dd45a6 h1:BNQKEcsKQ6rUZg7qnjUiSOzSCL+fh3PZ5O1jM6KDAQI=
+github.com/goccy/llamawasm2go v0.2.6-0.20260902033239-7dec39dd45a6/go.mod h1:2RraXBB/RS2RBlIol/M/rNvIcdtatKWzt8g7q63MPm0=

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/goccy/llamawasm2go v0.2.6-0.20260902051004-e32be00f16dc h1:MkXojyTDPY/dY7MVHrz0o/1Cudc20Gzs8fNYwkDVE+c=
-github.com/goccy/llamawasm2go v0.2.6-0.20260902051004-e32be00f16dc/go.mod h1:2RraXBB/RS2RBlIol/M/rNvIcdtatKWzt8g7q63MPm0=
+github.com/goccy/llamawasm2go v0.2.6-0.20260902062907-fc0ce95bcb7b h1:6bMNSMqdyt7asi8A8/Ed2kufyc/n7f6yS58ulrrvb0I=
+github.com/goccy/llamawasm2go v0.2.6-0.20260902062907-fc0ce95bcb7b/go.mod h1:2RraXBB/RS2RBlIol/M/rNvIcdtatKWzt8g7q63MPm0=

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/goccy/llamawasm2go v0.3.3-0.20260903093610-c1a9cb1cb791 h1:b9uGEa3R9zFkurQW6fJzgrqVqkTDsYhvz895CfehHfs=
-github.com/goccy/llamawasm2go v0.3.3-0.20260903093610-c1a9cb1cb791/go.mod h1:2RraXBB/RS2RBlIol/M/rNvIcdtatKWzt8g7q63MPm0=
+github.com/goccy/llamawasm2go v0.3.3-0.20260903095331-eed7bbb0e222 h1:qDqdXMe3/TvyMtsNmtRwdauo3F9qUOaLJ4WMAgc6SxE=
+github.com/goccy/llamawasm2go v0.3.3-0.20260903095331-eed7bbb0e222/go.mod h1:2RraXBB/RS2RBlIol/M/rNvIcdtatKWzt8g7q63MPm0=

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/goccy/llamawasm2go v0.2.6-0.20260902062907-fc0ce95bcb7b h1:6bMNSMqdyt7asi8A8/Ed2kufyc/n7f6yS58ulrrvb0I=
-github.com/goccy/llamawasm2go v0.2.6-0.20260902062907-fc0ce95bcb7b/go.mod h1:2RraXBB/RS2RBlIol/M/rNvIcdtatKWzt8g7q63MPm0=
+github.com/goccy/llamawasm2go v0.2.6-0.20260902071540-c9d549fc3e97 h1:/rNLmYGECXWGGEIKTLCjMgZ/ncR19TTh0cCqUdASVi0=
+github.com/goccy/llamawasm2go v0.2.6-0.20260902071540-c9d549fc3e97/go.mod h1:2RraXBB/RS2RBlIol/M/rNvIcdtatKWzt8g7q63MPm0=

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/goccy/llamawasm2go v0.3.3-0.20260903074734-86d4a6a3ef9f h1:rS7eLnni9hYDOa1gBeu2+z6kZtjtg5monAYehAVx3Do=
-github.com/goccy/llamawasm2go v0.3.3-0.20260903074734-86d4a6a3ef9f/go.mod h1:2RraXBB/RS2RBlIol/M/rNvIcdtatKWzt8g7q63MPm0=
+github.com/goccy/llamawasm2go v0.3.3-0.20260903093610-c1a9cb1cb791 h1:b9uGEa3R9zFkurQW6fJzgrqVqkTDsYhvz895CfehHfs=
+github.com/goccy/llamawasm2go v0.3.3-0.20260903093610-c1a9cb1cb791/go.mod h1:2RraXBB/RS2RBlIol/M/rNvIcdtatKWzt8g7q63MPm0=

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/goccy/llamawasm2go v0.2.6-0.20260902033239-7dec39dd45a6 h1:BNQKEcsKQ6rUZg7qnjUiSOzSCL+fh3PZ5O1jM6KDAQI=
-github.com/goccy/llamawasm2go v0.2.6-0.20260902033239-7dec39dd45a6/go.mod h1:2RraXBB/RS2RBlIol/M/rNvIcdtatKWzt8g7q63MPm0=
+github.com/goccy/llamawasm2go v0.2.6-0.20260902043553-8b00acde598c h1:JLJHMu6nVi+TxgJ53WTY1HqIB+R8ny/gE1zRjFZRVs4=
+github.com/goccy/llamawasm2go v0.2.6-0.20260902043553-8b00acde598c/go.mod h1:2RraXBB/RS2RBlIol/M/rNvIcdtatKWzt8g7q63MPm0=

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/goccy/llamawasm2go v0.3.3-0.20260903100604-7c603a955172 h1:J0ZtombA0+JiSd5ev1rNYI/7gEsEYq6CatQks3j6MDc=
-github.com/goccy/llamawasm2go v0.3.3-0.20260903100604-7c603a955172/go.mod h1:2RraXBB/RS2RBlIol/M/rNvIcdtatKWzt8g7q63MPm0=
+github.com/goccy/llamawasm2go v0.3.3-0.20260903141834-9788596dc7a3 h1:CRL7/TI3WyJLDM8i1mxdOee4rzTmIphFe6FSY9HVl5E=
+github.com/goccy/llamawasm2go v0.3.3-0.20260903141834-9788596dc7a3/go.mod h1:2RraXBB/RS2RBlIol/M/rNvIcdtatKWzt8g7q63MPm0=

--- a/internal/gemv_repack_numeric_test.go
+++ b/internal/gemv_repack_numeric_test.go
@@ -26,7 +26,7 @@ import (
 // recorded in the llama-wasm release build log); it moves with any
 // engine rebuild, so re-read it from the log (or the bundle's
 // load32_splat memarg offsets) when bumping the bundle dependency.
-const repackF16Table = 8793760
+const repackF16Table = 8811856
 
 func f16Bits(f float32) uint16 {
 	// Exact for the small power-of-two scales the tests use.
@@ -233,4 +233,113 @@ func TestGemvRepackActScaleAdvance(t *testing.T) {
 	}
 	h.run(64, 4)
 	assertCols(t, h, 4, func(int) float32 { return 96 })
+}
+
+// putActBlockX4 writes one block_q8_0x4 (4 interleaved activation
+// rows): 4 f16 row scales then 128 quantized bytes, laid out
+// [k 0..7][row 0..3][i 0..3] — the same interleave the weights use.
+func (h *gemvHarness) putActBlockX4(block int64, scales [4]float32, qs func(row, i int) int8) {
+	blk := h.vy + block*136
+	for r, s := range scales {
+		binary.LittleEndian.PutUint16(h.mem[blk+int64(2*r):], f16Bits(s))
+	}
+	for k := 0; k < 8; k++ {
+		for r := 0; r < 4; r++ {
+			for i := 0; i < 4; i++ {
+				h.mem[blk+8+int64(k*16+r*4+i)] = byte(qs(r, k*4+i))
+			}
+		}
+	}
+}
+
+func (h *gemvHarness) runGemm(n int32, bs, nr, nc int) {
+	wasm2go.DbgGemmQ8_0_4x4(h.g, n, h.sPtr, int64(bs), h.vx, h.vy, int32(nr), int32(nc))
+}
+
+func (h *gemvHarness) cell(row, bs, col int) float32 {
+	return math.Float32frombits(binary.LittleEndian.Uint32(h.mem[h.sPtr+int64(4*(row*bs+col)):]))
+}
+
+// TestGemmRepackNumeric drives random blocks through the batched 4x4
+// tile GEMM and checks every output cell against the reference dot
+// product. Covers the whole varying-scale surface for all four rows
+// and both column groups, the batched analogue of
+// TestGemvRepackNumeric.
+func TestGemmRepackNumeric(t *testing.T) {
+	h := newGemvHarness(t)
+	const (
+		nb = 5  // blocks per row
+		nr = 8  // output rows (2 groups of 4)
+		nc = 8  // output columns (2 groups of 4)
+		bs = 10 // row stride in floats (> nc to catch stride bugs)
+	)
+	scales := []float32{1.0, 0.5, 2.0, 0.25}
+	rng := rand.New(rand.NewSource(11))
+
+	qb := make([][][]int8, nc/4)
+	dB := make([][][]float32, nc/4)
+	for x := 0; x < nc/4; x++ {
+		qb[x] = make([][]int8, nb)
+		dB[x] = make([][]float32, nb)
+		for l := 0; l < nb; l++ {
+			var s [4]float32
+			for j := range s {
+				s[j] = scales[rng.Intn(len(scales))]
+			}
+			dB[x][l] = s[:]
+			q := make([]int8, 128)
+			for i := range q {
+				q[i] = int8(rng.Intn(255) - 127)
+			}
+			qb[x][l] = q
+			h.putWeightBlock(int64(x*nb+l), s, func(i int) int8 { return q[i] })
+		}
+	}
+	qa := make([][][]int8, nr/4) // [rowgroup][block][128]
+	dA := make([][][]float32, nr/4)
+	for y := 0; y < nr/4; y++ {
+		qa[y] = make([][]int8, nb)
+		dA[y] = make([][]float32, nb)
+		for l := 0; l < nb; l++ {
+			var s [4]float32
+			for r := range s {
+				s[r] = scales[rng.Intn(len(scales))]
+			}
+			dA[y][l] = s[:]
+			q := make([]int8, 128)
+			for i := range q {
+				q[i] = int8(rng.Intn(255) - 127)
+			}
+			qa[y][l] = q
+			h.putActBlockX4(int64(y*nb+l), s, func(row, i int) int8 { return q[row*4+(i%4)+(i/4)*16] })
+		}
+	}
+
+	// Prefill the output arena with a sentinel to catch unwritten cells.
+	for i := int64(0); i < int64(nr*bs); i++ {
+		binary.LittleEndian.PutUint32(h.mem[h.sPtr+4*i:], math.Float32bits(-999))
+	}
+	h.runGemm(nb*32, bs, nr, nc)
+
+	for row := 0; row < nr; row++ {
+		y, m := row/4, row%4
+		for col := 0; col < nc; col++ {
+			x, j := col/4, col%4
+			var want float32
+			for l := 0; l < nb; l++ {
+				sum := int32(0)
+				for k := 0; k < 8; k++ {
+					for i := 0; i < 4; i++ {
+						sum += int32(qb[x][l][k*16+j*4+i]) * int32(qa[y][l][k*16+m*4+i])
+					}
+				}
+				want += float32(sum) * dB[x][l][j] * dA[y][l][m]
+			}
+			got := h.cell(row, bs, col)
+			diff := math.Abs(float64(got - want))
+			if tol := 1e-3 * (1 + math.Abs(float64(want))); diff > tol {
+				t.Errorf("cell[%d][%d]: got %g want %g (diff %g)", row, col, got, want, diff)
+			}
+		}
+	}
 }


### PR DESCRIPTION
## Why

The amd64 SIMD campaign so far compared go-llama against its own arm64 build and against older engine bundles. The next goal is parity with native llama.cpp on amd64, so the benchmark needs the actual target on the board.

## What

The Bench workflow now builds llama.cpp natively (`GGML_NATIVE`, CPU backend) on each benchmark runner and runs `llama-bench` on the same Q8_0 model — single-threaded (the kernel-efficiency comparison, since the engine executes single-threaded in these benches) and all-threads (the full-machine native ceiling) — right next to the go-llama benchmarks. The CPU-profile and hot-kernel disassembly steps stay, since they drive the kernel work.

This PR is a measurement vehicle: it stays a draft while benchmark runs on `perf/**` pushes collect the gap data that decides the next amd64 kernel increments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)