### PR TITLE
make: refuse a Rosetta amd64 toolchain; add test-arm64-native

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ ATTESTATION_API = https://api.github.com/repos/$(LLAMA_WASM_REPO)/attestations
 TEST_MODEL_URL := https://huggingface.co/ggml-org/models/resolve/main/tinyllamas/stories260K.gguf
 TEST_MODEL     := testdata/stories260K.gguf
 
-.PHONY: llama download verify testdata test verify-native help
+.PHONY: llama download verify testdata toolchain-check test test-arm64-native verify-native help
 
 llama: download verify
 
@@ -41,8 +41,38 @@ $(TEST_MODEL):
 	mkdir -p testdata
 	curl -fSL --proto '=https' --tlsv1.2 -o $@ $(TEST_MODEL_URL)
 
-test: testdata
+# toolchain-check refuses the silent wrong-engine run: an amd64 Go
+# toolchain under Rosetta on an Apple Silicon host builds GOARCH=amd64
+# at GOAMD64=v1, where the engine bundle has no asm at all — every test
+# then exercises the pure-Go scalar fallback (~1000x slower; the big-
+# model suite times out) instead of the arm64 engine this machine
+# actually runs. That mode once burned an hour diagnosing a "hang" that
+# was the wrong toolchain. Cross-building and running natively is the
+# supported way on such hosts (see test-arm64-native).
+toolchain-check:
+	@hostarch=$$(go env GOHOSTARCH); goarch=$$(go env GOARCH); \
+	echo "toolchain: $$(go version) GOARCH=$$goarch GOAMD64=$$(go env GOAMD64) GOHOSTARCH=$$hostarch"; \
+	if [ "$$(uname -s)" = Darwin ] && [ "$$hostarch" = amd64 ] \
+	   && [ "$$(sysctl -n hw.optional.arm64 2>/dev/null)" = 1 ]; then \
+	  echo "go-llama: amd64 Go under Rosetta on an Apple Silicon host — tests would run the pure-Go" >&2; \
+	  echo "go-llama: GOAMD64=v1 fallback, not the arm64 engine. Install a native arm64 Go, or run" >&2; \
+	  echo "go-llama: 'make test-arm64-native' (cross-builds the test binaries and runs them natively)." >&2; \
+	  exit 1; \
+	fi
+
+test: testdata toolchain-check
 	go test ./...
+
+# test-arm64-native: for an amd64 Go toolchain on an Apple Silicon host —
+# `go test` will not execute a cross-GOARCH binary, so build the test
+# binaries for arm64 and run them through the arch(1) shim.
+test-arm64-native: testdata
+	@set -eu; dir=$$(mktemp -d); trap 'rm -rf $$dir' EXIT; \
+	for pkg in . ./internal; do \
+	  name=$$(basename $$(cd $$pkg && pwd)); \
+	  GOARCH=arm64 go test -c -o $$dir/$$name.test $$pkg; \
+	  ( cd $$pkg && /usr/bin/arch -arm64 $$dir/$$name.test -test.timeout 20m ); \
+	done
 
 # Verify against a NATIVE llama.cpp build of the same commit: exact
 # tokenizer IDs, greedy equality on the F32 model, metadata equality,
@@ -55,4 +85,5 @@ help:
 	@echo 'Targets:'
 	@echo '  llama      Download + verify the generated bridge from $(LLAMA_WASM_REPO) $(LLAMA_WASM_VERSION)'
 	@echo '  testdata   Fetch the tiny GGUF model the tests use'
-	@echo '  test       go test ./... (fetches the model first)'
+	@echo '  test       go test ./... (fetches the model first; refuses a Rosetta amd64 toolchain)'
+	@echo '  test-arm64-native  cross-build the test binaries for arm64 and run them natively (Rosetta hosts)'


### PR DESCRIPTION
## Why

On an Apple Silicon host whose Go toolchain is the darwin/amd64 build (Rosetta shell), `make test` silently runs GOARCH=amd64 at GOAMD64=v1 — the engine bundle has no asm there, so the whole suite exercises the pure-Go scalar fallback (~1000x slower; the qwen tests look hung). That mode cost real diagnosis time during the v0.3.1 bundle investigation.

## What

- `make toolchain-check` (run by `make test`): prints `go version`/GOARCH/GOAMD64/GOHOSTARCH and refuses the Rosetta-amd64-on-arm64 combination with instructions.
- `make test-arm64-native`: cross-builds the root and internal test binaries for arm64 and runs them via `/usr/bin/arch -arm64` (`go test` will not execute a cross-GOARCH binary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)