### PR TITLE
Adopt llamawasm2go v0.3.2 and the llama-wasm v0.3.2 bridge

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Version of goccy/llama-wasm whose release assets this package is built from.
 # Bump it, run `make llama`, and commit the regenerated bridge.
 LLAMA_WASM_REPO     ?= goccy/llama-wasm
-LLAMA_WASM_VERSION  ?= v0.2.8
+LLAMA_WASM_VERSION  ?= v0.3.2
 LLAMA_WASM_WORKFLOW ?= goccy/llama-wasm/.github/workflows/release.yml
 
 # The generated wasm2go bridge. It is a release artifact of llama-wasm, not

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/goccy/go-llama
 
 go 1.25.0
 
-require github.com/goccy/llamawasm2go v0.3.0
+require github.com/goccy/llamawasm2go v0.3.2

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/goccy/llamawasm2go v0.3.0 h1:fLjK8JRvbTq+aP4vjRbhxI4Qx90ZG5nfdlR9IXGIAWE=
-github.com/goccy/llamawasm2go v0.3.0/go.mod h1:2RraXBB/RS2RBlIol/M/rNvIcdtatKWzt8g7q63MPm0=
+github.com/goccy/llamawasm2go v0.3.2 h1:3SF2NxWeYWjgRcopaY5K35ykt3tg5wfIFHZ9oeGVyiw=
+github.com/goccy/llamawasm2go v0.3.2/go.mod h1:2RraXBB/RS2RBlIol/M/rNvIcdtatKWzt8g7q63MPm0=


### PR DESCRIPTION
## Why

llamawasm2go v0.3.2 is the bundle rebuilt from llama-wasm v0.3.2 (wasmify v0.6.14 / wasm2go v0.5.13): the amd64 repack kernels (cross-chain raw dots, F16C scale conversion, native 4x4 GEMM tile) and direct cross-chunk asm calls, with the cross-chunk linkname-pull defect fixed so the bundle links on Go 1.25/1.26 (goccy/wasm2go#65, goccy/llamawasm2go#13).

## What

- `go.mod`: `github.com/goccy/llamawasm2go` v0.3.0 → **v0.3.2** (module content verified identical to the git tag).
- `Makefile`: bridge source llama-wasm v0.2.8 → **v0.3.2**; `make llama` fetched the release bridge and attestation-verified it — byte-identical to the committed `internal/llama.go`.
- f16 table base unchanged (8793760).

## Validation

- Full suite natively on arm64 (`GOARCH=arm64 go test -c` + `arch -arm64`): root 40 PASS / 0 FAIL, internal PASS (`TestSamplerContract` 2.3 s).
- Same-machine throughput vs the previous pin (v0.3.0), arm64, qwen2.5-0.5b q8_0, 64 tokens, best of 3: decode **105.9 vs 99.7 tok/s**, prompt **129.5 vs 57.4 tok/s**.
- CI runs the arm64 and amd64 (GOAMD64 v1 / v2) suites on the new bundle.

A CI performance gate against native llama.cpp follows in a stacked PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
