### PR TITLE
Adopt llamawasm2go v0.3.4: finite scores on AVX-512 VNNI hosts

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/goccy/go-llama
 
 go 1.25.0
 
-require github.com/goccy/llamawasm2go v0.3.3
+require github.com/goccy/llamawasm2go v0.3.4

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/goccy/llamawasm2go v0.3.3 h1:1AEjMif5wG81C+1YFgfTz+XMMAp1nqZC0+70HQ9V9fM=
-github.com/goccy/llamawasm2go v0.3.3/go.mod h1:2RraXBB/RS2RBlIol/M/rNvIcdtatKWzt8g7q63MPm0=
+github.com/goccy/llamawasm2go v0.3.4 h1:5eVWvKsgkLzlUhVHL22PMksG7S5vspWyJ4X/0JuUPwQ=
+github.com/goccy/llamawasm2go v0.3.4/go.mod h1:2RraXBB/RS2RBlIol/M/rNvIcdtatKWzt8g7q63MPm0=

--- a/score_finite_test.go
+++ b/score_finite_test.go
@@ -1,0 +1,83 @@
+package llama_test
+
+import (
+	"math"
+	"path/filepath"
+	"testing"
+
+	llama "github.com/goccy/go-llama"
+)
+
+// TestScoreResultsFinite pins that Score and ScoreChoices return finite
+// negative log-likelihoods on every model in testdata. The tolerance
+// comparisons in the other score tests are silent on NaN (|NaN - x| > tol
+// is false), so a kernel that poisons the logits passes them: the
+// llamawasm2go v0.3.3 engine did exactly that on AVX-512 VNNI hosts,
+// where the q8_0x4 repack GEMV clobbered one column group's accumulator
+// per pass (goccy/llama-wasm#21) and every choice scored NaN. The
+// quantized models are the ones that take that kernel; the f32 story
+// model covers the plain path.
+func TestScoreResultsFinite(t *testing.T) {
+	const stem = "Once upon a time, in a land far away, there lived a"
+	choices := []string{" little girl", " dragon", " brave knight of the realm"}
+
+	models := []string{"stories260K.gguf"}
+	for _, name := range []string{"qwen2.5-0.5b-instruct-q8_0.gguf", "qwen2.5-0.5b-instruct-q4_k_m.gguf"} {
+		if verifyModelPath(t, name) != "" {
+			models = append(models, name)
+		}
+	}
+	// ScoreChoices scores every token of a choice and reports only
+	// NTokens; NScored is Score's count of teacher-forced positions.
+	finite := func(t *testing.T, what string, r llama.ScoreResult) {
+		t.Helper()
+		if r.NTokens <= 0 {
+			t.Errorf("%s: no tokens: %+v", what, r)
+		}
+		if math.IsNaN(r.NLL) || math.IsInf(r.NLL, 0) {
+			t.Errorf("%s: NLL = %v, want finite", what, r.NLL)
+		}
+	}
+	for _, name := range models {
+		t.Run(name, func(t *testing.T) {
+			if verifyModelPath(t, name) == "" {
+				t.Skipf("model missing: %s", name)
+			}
+			m, err := testInst.LoadModel(filepath.Base(name))
+			if err != nil {
+				t.Fatalf("LoadModel: %v", err)
+			}
+			defer m.Close()
+
+			ctx, err := m.NewContext(llama.ContextParams{NCtx: 256})
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer ctx.Close()
+			full, err := ctx.Score(stem + choices[0])
+			if err != nil {
+				t.Fatalf("Score: %v", err)
+			}
+			finite(t, "Score", full)
+			if full.NScored <= 0 {
+				t.Errorf("Score: no positions scored: %+v", full)
+			}
+
+			cctx, err := m.NewContext(llama.ContextParams{NCtx: 256})
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer cctx.Close()
+			if _, err := cctx.Eval(stem, true, true); err != nil {
+				t.Fatal(err)
+			}
+			scores, err := cctx.ScoreChoices(choices)
+			if err != nil {
+				t.Fatalf("ScoreChoices: %v", err)
+			}
+			for i, r := range scores {
+				finite(t, "ScoreChoices "+choices[i], r)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What

Bump `github.com/goccy/llamawasm2go` v0.3.3 → v0.3.4, which bundles llama-wasm v0.3.4. That release's only change is the q8_0x4 repack GEMV fix for AVX-512 VNNI hosts (goccy/llama-wasm#21, goccy/llamawasm2go#15).

## Why

The four-group VNNI pass loaded each group's column scales into X7 while Y7 still held group 1's odd-pair accumulator, so on VNNI hosts every decode's logits carried ~1e9-scale garbage for one column group per pass. In production that surfaced as NaN from `Score` / `ScoreChoices` (AWS Fargate, Ice Lake+; Zen 4 is also affected). arm64 and non-VNNI amd64 were fine, which is why neither CI pool saw it.

The llama.cpp commit is unchanged (`11924d4c`), so `bench/baseline.json`, `LLAMA_CPP_COMMIT` in perf.yml and the native perplexity golden stay as recorded. The kernel change is register-only, so no throughput change is expected; the perf gate on this PR confirms.

## Test

`TestScoreResultsFinite` pins that `Score` and `ScoreChoices` return finite NLLs on every model in `testdata` (stories260K always; the qwen q8_0 / q4_k_m models when present). The existing q8 gates compare against native with a relative tolerance, which is silent on NaN (`|NaN - x| > tol` is false), so the poisoned kernel passed them. This check fails on any VNNI host with the v0.3.3 engine. The hosted runners (EPYC 7763, Neoverse-N2) have no VNNI, so on CI it documents the invariant; it guards it wherever the suite runs on VNNI hardware.

Locally (`make test-arm64-native`, M-series): both packages PASS; the new test passes on all three models.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
