### PR TITLE
Adopt llamawasm2go v0.3.5: native kernels for every quant path, tensor-to-kernel coverage test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Version of goccy/llama-wasm whose release assets this package is built from.
 # Bump it, run `make llama`, and commit the regenerated bridge.
 LLAMA_WASM_REPO     ?= goccy/llama-wasm
-LLAMA_WASM_VERSION  ?= v0.3.2
+LLAMA_WASM_VERSION  ?= v0.3.5
 LLAMA_WASM_WORKFLOW ?= goccy/llama-wasm/.github/workflows/release.yml
 
 # The generated wasm2go bridge. It is a release artifact of llama-wasm, not

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/goccy/go-llama
 
 go 1.25.0
 
-require github.com/goccy/llamawasm2go v0.3.5-0.20260905120831-2695e411f519
+require github.com/goccy/llamawasm2go v0.3.5

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/goccy/go-llama
 
 go 1.25.0
 
-require github.com/goccy/llamawasm2go v0.3.4
+require github.com/goccy/llamawasm2go v0.3.5-0.20260905120831-2695e411f519

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,2 @@
-github.com/goccy/llamawasm2go v0.3.4 h1:5eVWvKsgkLzlUhVHL22PMksG7S5vspWyJ4X/0JuUPwQ=
-github.com/goccy/llamawasm2go v0.3.4/go.mod h1:2RraXBB/RS2RBlIol/M/rNvIcdtatKWzt8g7q63MPm0=
-github.com/goccy/llamawasm2go v0.3.5-0.20260905120831-2695e411f519 h1:YUiPi1GkI8CL3dzCx/a2vLEWXTQwN4k/RPrynoUnzSc=
-github.com/goccy/llamawasm2go v0.3.5-0.20260905120831-2695e411f519/go.mod h1:2RraXBB/RS2RBlIol/M/rNvIcdtatKWzt8g7q63MPm0=
 github.com/goccy/llamawasm2go v0.3.5 h1:vT1FSAb1e5gJXOTQoCaC+es5PAWcLoxlMX1Nln5rt9c=
 github.com/goccy/llamawasm2go v0.3.5/go.mod h1:2RraXBB/RS2RBlIol/M/rNvIcdtatKWzt8g7q63MPm0=

--- a/go.sum
+++ b/go.sum
@@ -2,3 +2,5 @@ github.com/goccy/llamawasm2go v0.3.4 h1:5eVWvKsgkLzlUhVHL22PMksG7S5vspWyJ4X/0JuU
 github.com/goccy/llamawasm2go v0.3.4/go.mod h1:2RraXBB/RS2RBlIol/M/rNvIcdtatKWzt8g7q63MPm0=
 github.com/goccy/llamawasm2go v0.3.5-0.20260905120831-2695e411f519 h1:YUiPi1GkI8CL3dzCx/a2vLEWXTQwN4k/RPrynoUnzSc=
 github.com/goccy/llamawasm2go v0.3.5-0.20260905120831-2695e411f519/go.mod h1:2RraXBB/RS2RBlIol/M/rNvIcdtatKWzt8g7q63MPm0=
+github.com/goccy/llamawasm2go v0.3.5 h1:vT1FSAb1e5gJXOTQoCaC+es5PAWcLoxlMX1Nln5rt9c=
+github.com/goccy/llamawasm2go v0.3.5/go.mod h1:2RraXBB/RS2RBlIol/M/rNvIcdtatKWzt8g7q63MPm0=

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,4 @@
 github.com/goccy/llamawasm2go v0.3.4 h1:5eVWvKsgkLzlUhVHL22PMksG7S5vspWyJ4X/0JuUPwQ=
 github.com/goccy/llamawasm2go v0.3.4/go.mod h1:2RraXBB/RS2RBlIol/M/rNvIcdtatKWzt8g7q63MPm0=
+github.com/goccy/llamawasm2go v0.3.5-0.20260905120831-2695e411f519 h1:YUiPi1GkI8CL3dzCx/a2vLEWXTQwN4k/RPrynoUnzSc=
+github.com/goccy/llamawasm2go v0.3.5-0.20260905120831-2695e411f519/go.mod h1:2RraXBB/RS2RBlIol/M/rNvIcdtatKWzt8g7q63MPm0=

--- a/internal/engine.go
+++ b/internal/engine.go
@@ -54,6 +54,7 @@ const (
 	midModelInfo
 	midModelLoad
 	midModelLoadProgressAddr
+	midModelTensors
 	midTokenToPiece
 	midTokenize
 	midWasmBuildInfo
@@ -90,12 +91,13 @@ var invokers = [midCount]func(*base.Module, wptr, wptr) (int64, error){
 	midModelInfo:              wasm2go.Inv_0_20,
 	midModelLoad:              wasm2go.Inv_0_21,
 	midModelLoadProgressAddr:  wasm2go.Inv_0_22,
-	midTokenToPiece:           wasm2go.Inv_0_23,
-	midTokenize:               wasm2go.Inv_0_24,
-	midWasmBuildInfo:          wasm2go.Inv_0_25,
-	midWasmFree:               wasm2go.Inv_0_26,
-	midWasmInit:               wasm2go.Inv_0_27,
-	midWasmLastError:          wasm2go.Inv_0_28,
+	midModelTensors:           wasm2go.Inv_0_23,
+	midTokenToPiece:           wasm2go.Inv_0_24,
+	midTokenize:               wasm2go.Inv_0_25,
+	midWasmBuildInfo:          wasm2go.Inv_0_26,
+	midWasmFree:               wasm2go.Inv_0_27,
+	midWasmInit:               wasm2go.Inv_0_28,
+	midWasmLastError:          wasm2go.Inv_0_29,
 }
 
 // NewEngine brings up an independent engine instance: its own wasm module
@@ -530,6 +532,16 @@ func (m *Module) LlamaModelInfo(model uint64) (string, error) {
 	buf := pbNewBuf()
 	buf = pbAppendUint64(buf, 1, model)
 	resp, err := m.invokeMethod(midModelInfo, buf)
+	if err != nil {
+		return "", err
+	}
+	return readScalarAtField(resp, 1, (*pbReader).readString), nil
+}
+
+func (m *Module) LlamaModelTensors(model uint64) (string, error) {
+	buf := pbNewBuf()
+	buf = pbAppendUint64(buf, 1, model)
+	resp, err := m.invokeMethod(midModelTensors, buf)
 	if err != nil {
 		return "", err
 	}

--- a/internal/gemv_repack_numeric_test.go
+++ b/internal/gemv_repack_numeric_test.go
@@ -26,7 +26,7 @@ import (
 // recorded in the llama-wasm release build log); it moves with any
 // engine rebuild, so re-read it from the log (or the bundle's
 // load32_splat memarg offsets) when bumping the bundle dependency.
-const repackF16Table = 8793760
+const repackF16Table = 8794144
 
 func f16Bits(f float32) uint16 {
 	// Exact for the small power-of-two scales the tests use.

--- a/internal/llama.go
+++ b/internal/llama.go
@@ -992,7 +992,11 @@ func LlamaChatApplyTemplate(model uint64, messagesJson string, messagesJsonLen u
 //	shared snapshot pages and its dead threads cannot be joined. n_threads
 //
 // <
-// = 1 detaches instead. Returns {"ok":true} or an error object.
+// = 1 detaches instead, and the context's n_threads / n_threads_batch
+//
+//	are set to the pool size (1 when detached) so graphs actually use the
+//	workers. Returns {"ok":true,"n_threads":N,"n_threads_batch":N} — the
+//	counts the context now computes with — or an error object.
 func LlamaCtxAttachThreadpool(ctx uint64, nThreads uint32) (string, error) {
 	buf := pbNewBuf()
 	buf = pbAppendUint64(buf, 1, ctx)
@@ -1362,6 +1366,23 @@ func LlamaModelLoadProgressAddr() (uint64, error) {
 	return readScalarAtField(resp, 1, (*pbReader).readUint64), nil
 }
 
+// JSON list of the model's weight tensors:
+//
+//	{"ok":true,"tensors":[{"name":"blk.0.attn_q.weight","type":"q4_K",
+//	"ne":[1536,1536],"buffer":"CPU_REPACK","vec_dot_type":"q8_K"},...]}
+//	buffer is the ggml backend buffer holding the tensor ("CPU_REPACK" when
+//	the CPU backend repacked it for its GEMV/GEMM kernels, "CPU" otherwise),
+//	vec_dot_type the activation type its dot product quantizes to.
+func LlamaModelTensors(model uint64) (string, error) {
+	buf := pbNewBuf()
+	buf = pbAppendUint64(buf, 1, model)
+	resp, err := invokeMethod(0, 23, buf, wasm2go.Inv_0_23)
+	if err != nil {
+		return "", err
+	}
+	return readScalarAtField(resp, 1, (*pbReader).readString), nil
+}
+
 // The text piece a single token renders to, as JSON `{"ok":true,"text":".."}`.
 // Byte-level tokens can render to invalid UTF-8 on their own; the caller is
 // expected to accumulate pieces.
@@ -1370,7 +1391,7 @@ func LlamaTokenToPiece(model uint64, token int32, renderSpecial int32) (string, 
 	buf = pbAppendUint64(buf, 1, model)
 	buf = pbAppendInt32(buf, 2, token)
 	buf = pbAppendInt32(buf, 3, renderSpecial)
-	resp, err := invokeMethod(0, 23, buf, wasm2go.Inv_0_23)
+	resp, err := invokeMethod(0, 24, buf, wasm2go.Inv_0_24)
 	if err != nil {
 		return "", err
 	}
@@ -1387,7 +1408,7 @@ func LlamaTokenize(model uint64, text string, textLen uint32, addSpecial int32, 
 	buf = pbAppendUint64(buf, 3, uint64(textLen))
 	buf = pbAppendInt32(buf, 4, addSpecial)
 	buf = pbAppendInt32(buf, 5, parseSpecial)
-	resp, err := invokeMethod(0, 24, buf, wasm2go.Inv_0_24)
+	resp, err := invokeMethod(0, 25, buf, wasm2go.Inv_0_25)
 	if err != nil {
 		return "", err
 	}
@@ -1398,7 +1419,7 @@ func LlamaTokenize(model uint64, text string, textLen uint32, addSpecial int32, 
 // and whether this wasm was built with SIMD / threads. Diagnostics only.
 func LlamaWasmBuildInfo() (string, error) {
 	buf := pbNewBuf()
-	resp, err := invokeMethod(0, 25, buf, wasm2go.Inv_0_25)
+	resp, err := invokeMethod(0, 26, buf, wasm2go.Inv_0_26)
 	if err != nil {
 		return "", err
 	}
@@ -1408,7 +1429,7 @@ func LlamaWasmBuildInfo() (string, error) {
 // Free process-wide backend state. After this every handle is invalid.
 func LlamaWasmFree() error {
 	buf := pbNewBuf()
-	_, err := invokeMethod(0, 26, buf, wasm2go.Inv_0_26)
+	_, err := invokeMethod(0, 27, buf, wasm2go.Inv_0_27)
 	return err
 }
 
@@ -1416,7 +1437,7 @@ func LlamaWasmFree() error {
 // llama_model_load, so an embedder normally never calls it.
 func LlamaWasmInit() error {
 	buf := pbNewBuf()
-	_, err := invokeMethod(0, 27, buf, wasm2go.Inv_0_27)
+	_, err := invokeMethod(0, 28, buf, wasm2go.Inv_0_28)
 	return err
 }
 
@@ -1425,7 +1446,7 @@ func LlamaWasmInit() error {
 // this exists for the handle-returning calls, which can only signal 0.
 func LlamaWasmLastError() (string, error) {
 	buf := pbNewBuf()
-	resp, err := invokeMethod(0, 28, buf, wasm2go.Inv_0_28)
+	resp, err := invokeMethod(0, 29, buf, wasm2go.Inv_0_29)
 	if err != nil {
 		return "", err
 	}

--- a/kernel_coverage_test.go
+++ b/kernel_coverage_test.go
@@ -1,0 +1,157 @@
+package llama_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"runtime"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/goccy/llamawasm2go/base"
+)
+
+// kernelIndex is the bundle's kernel index (kernels/asm/kernels.json in
+// llama-wasm): every exported kernel a native body replaces, with what it
+// computes, the tensor type it serves and the architectures carrying a body.
+type kernelIndex struct {
+	Kernels []struct {
+		Export string   `json:"export"`
+		Role   string   `json:"role"`
+		Quant  string   `json:"quant"`
+		Arches []string `json:"arches"`
+	} `json:"kernels"`
+}
+
+// nativeKernels returns, per tensor type, the exports with a native body
+// for arch in each role ("gemv", "gemm", "vec_dot").
+func nativeKernels(t *testing.T, arch string) map[string]map[string]string {
+	t.Helper()
+	var idx kernelIndex
+	if err := json.Unmarshal(base.AsmKernels, &idx); err != nil {
+		t.Fatalf("bundle kernel index: %v", err)
+	}
+	out := map[string]map[string]string{}
+	for _, k := range idx.Kernels {
+		for _, a := range k.Arches {
+			if a != arch {
+				continue
+			}
+			if out[k.Quant] == nil {
+				out[k.Quant] = map[string]string{}
+			}
+			out[k.Quant][k.Role] = k.Export
+		}
+	}
+	return out
+}
+
+// TestKernelCoverage maps every weight tensor of the test model to the
+// kernel it runs on and reports whether the bundle's native bodies reach
+// it: a repacked tensor needs the type's repack GEMV and GEMM overrides, a
+// non-repacked quantized tensor its vec_dot override. The per-type table
+// is logged (an inspection tool, not a gate: which types a model uses is
+// the model's choice); tensors whose type has repack kernels but that the backend
+// did not repack (rows not a multiple of 8, or a shared embedding) are
+// reported, not failed. Run with GO_LLAMA_TEST_MODEL to inspect a real
+// model; the default tiny model is f32/f16 and exercises no quant kernel.
+func TestKernelCoverage(t *testing.T) {
+	m := load(t)
+	defer m.Close()
+	tensors, err := m.Tensors()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(tensors) == 0 {
+		t.Fatal("no tensors reported")
+	}
+	native := nativeKernels(t, runtime.GOARCH)
+
+	type row struct {
+		path     string // "repack" or "vec_dot"
+		kernels  []string
+		asm      bool
+		count    int
+		params   int64
+		notRepak int // tensors of a repackable type left on the per-row path
+	}
+	rows := map[string]*row{}
+	var total int64
+	for _, tn := range tensors {
+		if len(tn.Shape) < 2 {
+			continue // embeddings-as-lookups and 1-D norms are not matmuls
+		}
+		switch tn.Type {
+		case "f32", "f16", "bf16":
+			continue
+		}
+		params := int64(1)
+		for _, d := range tn.Shape {
+			params *= d
+		}
+		total += params
+		key := tn.Type
+		var kernels []string
+		asm := true
+		if tn.Repacked() {
+			key += " (repack)"
+			for _, role := range []string{"gemv", "gemm"} {
+				if k, ok := native[tn.Type][role]; ok {
+					kernels = append(kernels, k)
+				} else {
+					asm = false
+					kernels = append(kernels, "no "+role+" body")
+				}
+			}
+		} else {
+			key += " (vec_dot)"
+			if k, ok := native[tn.Type]["vec_dot"]; ok {
+				kernels = append(kernels, k)
+			} else {
+				asm = false
+				kernels = append(kernels, "no vec_dot body")
+			}
+		}
+		r := rows[key]
+		if r == nil {
+			r = &row{kernels: kernels, asm: asm}
+			if tn.Repacked() {
+				r.path = "repack"
+			} else {
+				r.path = "vec_dot"
+			}
+			rows[key] = r
+		}
+		r.count++
+		r.params += params
+		if _, ok := native[tn.Type]["gemv"]; !tn.Repacked() && ok {
+			r.notRepak++
+		}
+	}
+	if total == 0 {
+		t.Skip("no quantized weight tensors: the model exercises no quant kernel")
+	}
+	keys := make([]string, 0, len(rows))
+	for k := range rows {
+		keys = append(keys, k)
+	}
+	sort.Slice(keys, func(i, j int) bool { return rows[keys[i]].params > rows[keys[j]].params })
+	var covered int64
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "kernel coverage on %s (%s):\n", runtime.GOARCH, modelPath())
+	for _, k := range keys {
+		r := rows[k]
+		status := "native asm"
+		if !r.asm {
+			status = "no native body (transpiled wasm code)"
+		} else {
+			covered += r.params
+		}
+		fmt.Fprintf(&sb, "  %-20s %3d tensors %5.1f%% of quant params  %s  %s\n", k, r.count, 100*float64(r.params)/float64(total), status, strings.Join(r.kernels, ", "))
+		if r.notRepak > 0 {
+			fmt.Fprintf(&sb, "  %-20s %3d tensors of a repackable type run the per-row dot (rows not a multiple of 8, or shared with a lookup)\n", "", r.notRepak)
+		}
+	}
+	fmt.Fprintf(&sb, "  native asm reaches %.1f%% of the quantized parameters", 100*float64(covered)/float64(total))
+	t.Log(sb.String())
+}

--- a/snapshot.go
+++ b/snapshot.go
@@ -162,7 +162,9 @@ func (f *Instance) Context(name string) *Context { return f.ctxs[name] }
 func (f *Instance) Close() error { return f.l.Close() }
 
 // attachThreadpool rebuilds and attaches a context's ggml threadpool via the
-// bridge; n <= 1 detaches instead.
+// bridge; n <= 1 detaches instead. The bridge reports the thread counts the
+// context will compute with afterwards; they must equal the pool size, since
+// a pool the context does not use leaves its workers idling.
 func attachThreadpool(m *bridge.Module, ctxH uint64, n uint32) error {
 	js, err := m.LlamaCtxAttachThreadpool(ctxH, n)
 	if err != nil {
@@ -170,6 +172,15 @@ func attachThreadpool(m *bridge.Module, ctxH uint64, n uint32) error {
 	}
 	var out struct {
 		envelope
+		NThreads      uint32 `json:"n_threads"`
+		NThreadsBatch uint32 `json:"n_threads_batch"`
 	}
-	return decode("attach threadpool", js, &out)
+	if err := decode("attach threadpool", js, &out); err != nil {
+		return err
+	}
+	want := max(n, 1)
+	if out.NThreads != want || out.NThreadsBatch != want {
+		return fmt.Errorf("attach threadpool: context computes with %d/%d threads, want %d", out.NThreads, out.NThreadsBatch, want)
+	}
+	return nil
 }

--- a/tensors.go
+++ b/tensors.go
@@ -1,0 +1,42 @@
+package llama
+
+// TensorInfo describes one weight tensor of a loaded model and the kernel
+// path the CPU backend gave it.
+type TensorInfo struct {
+	Name string `json:"name"`
+	// Type is the ggml type name ("q4_K", "q8_0", "f16", ...).
+	Type string `json:"type"`
+	// Shape is ne[0..]: the row length first.
+	Shape []int64 `json:"ne"`
+	// Buffer names the backend buffer holding the tensor: "CPU_REPACK" for
+	// tensors the CPU backend repacked for its GEMV/GEMM kernels (rows a
+	// multiple of the repack width, a repackable type), "CPU" otherwise.
+	Buffer string `json:"buffer"`
+	// VecDotType is the activation type the tensor's dot product quantizes
+	// to ("q8_K" for K-quants, "q8_0" / "q8_1" for the legacy types).
+	VecDotType string `json:"vec_dot_type"`
+}
+
+// Repacked reports whether the CPU backend repacked the tensor for its
+// GEMV/GEMM kernels; tensors that are not repacked run the per-row dot.
+func (t TensorInfo) Repacked() bool { return t.Buffer == "CPU_REPACK" }
+
+// Tensors lists the model's weight tensors with the buffer each landed in,
+// which decides the kernel path (repacked GEMV/GEMM versus per-row dot).
+func (m *Model) Tensors() ([]TensorInfo, error) {
+	if err := m.use("model tensors"); err != nil {
+		return nil, err
+	}
+	js, err := m.inst.e().LlamaModelTensors(m.h)
+	if err != nil {
+		return nil, err
+	}
+	var out struct {
+		envelope
+		Tensors []TensorInfo `json:"tensors"`
+	}
+	if err := decode("model tensors", js, &out); err != nil {
+		return nil, err
+	}
+	return out.Tensors, nil
+}


### PR DESCRIPTION
Adopts llamawasm2go v0.3.5 (llama-wasm v0.3.5: goccy/llama-wasm#25, #24, #26).

**Engine (from the bundle)**
- Native kernels for every quant path llama.cpp's ggml-cpu optimizes: 8x8 repack GEMV/GEMM for Q6_K / Q5_K / Q4_0 / IQ4_NL, per-row dots for Q5_K / Q2_K / Q3_K / IQ4_NL / Q5_1 / Q4_1 / Q4_0 / Q8_0 (arm64 + amd64). On an M5 (8 threads) Qwen2.5-0.5B q3_k_m decodes at 243 tok/s (native 268), q2_k 228 (native 256), q4_0 238 (native 277), q5_k_m 176 (native 211); Arch-Router-1.5B Q4_K_M 101 (native 106).
- Batched and sequential decodes agree bit for bit on every quant type (Q4_K GEMV i32 fold; nearest-even q8_0 activation quantizer on both paths). `TestScoreChoicesSeqBatched`, `TestSpeculativeMatchesPlain` and `TestScoreChoices` pass on every model tried (Arch-Router Q4_K_M; 0.5B q8_0 / q4_0 / q4_k_m / q5_k_m / q3_k_m / q2_k); the q8_0-activation models failed at least one before.
- A forked context computes with its configured thread count (goccy/llama-wasm#24); `TestSnapshotFork` now verifies it.

**API**
- `Model.Tensors()` returns each weight tensor's name, ggml type, shape, backend buffer (`CPU_REPACK` / `CPU`) and activation type.
- `TestKernelCoverage` maps a model's quantized tensors to the kernels that run them and logs, from the bundle's embedded kernel index (`base.AsmKernels`), whether native bodies cover them. On the seven models above native asm reaches 100% of the quantized parameters. It is an inspection tool, not a gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
