### PR TITLE
Adopt llamawasm2go v0.4.0: Slots (continuous batching), KVUnified, lossless text

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Version of goccy/llama-wasm whose release assets this package is built from.
 # Bump it, run `make llama`, and commit the regenerated bridge.
 LLAMA_WASM_REPO     ?= goccy/llama-wasm
-LLAMA_WASM_VERSION  ?= v0.3.5
+LLAMA_WASM_VERSION  ?= v0.4.0
 LLAMA_WASM_WORKFLOW ?= goccy/llama-wasm/.github/workflows/release.yml
 
 # The generated wasm2go bridge. It is a release artifact of llama-wasm, not

--- a/README.md
+++ b/README.md
@@ -127,6 +127,52 @@ memory (never calling into the engine), which the generation loop reads once per
 token. It is safe to call from any goroutine while a generation runs; `Generate`
 then returns what it has with `Reason == StopInterrupted`.
 
+## Slots: many requests on one context
+
+A `Context` created with `NSeqMax` slots can run that many tasks at once —
+continuous batching, in llama.cpp's server vocabulary (slot, task, post,
+system prompt). One scheduling step decodes a single batch drawn from every
+busy slot, so the slots share the per-step cost instead of each paying it.
+
+```go
+ctx, _ := model.NewContext(llama.ContextParams{NCtx: 8192, NSeqMax: 32})
+slots, _ := ctx.Slots()
+defer slots.Close()
+
+// Optional: an instruction every request starts with is decoded once and
+// shared; a task that starts with it decodes only the rest.
+slots.SetSystemPrompt(instruction)
+
+task := llama.Task{Prompt: instruction + userText, Params: llama.Params{NPredict: 16}}
+cmpl, err := slots.Post(ctx, task)        // ctx is a context.Context: cancel it to drop the task
+for out := range cmpl.Outputs() {         // each token as it is produced (optional)
+	fmt.Print(out.Text)
+}
+res, err := cmpl.Wait()                    // the same Result Generate returns
+```
+
+`Task` is a plain value; `Post` never modifies it and returns the task's
+`TaskCompletion`. `Outputs` is pull-based — outputs are kept until read, so a
+slow reader never stalls the batch — and `Result` returns the finished result
+without waiting (`ErrTaskRunning` before). A task waits for a free slot in
+FIFO order and for enough free cells; its prompt plus `NPredict` must fit a
+sequence's window. A greedy task produces exactly what `Generate` produces for
+the same prompt when the prompt is decoded in the same chunks; a long prompt
+split differently across steps can land on the other side of a near-tie, as
+`Generate` itself does with a different `NBatch`.
+
+`ContextParams.KVUnified` follows llama.cpp's `kv_unified`: off (the default)
+gives each sequence its own stream of `NCtx / NSeqMax` cells, the right layout
+for independent tasks; on shares one buffer, which makes the system prompt's
+sharing free and is what `ScoreChoices` with `NSeqMax > 1` relies on. While
+a `Slots` holds tasks the context's single-sequence methods refuse.
+
+Measured on an M-series laptop with 8 threads and a 0.5B Q8_0 model, 100
+requests arriving at once (a 45-token shared instruction plus a short user
+part, 16 tokens each): eight forked instances completed them at p50 4.3 s /
+p99 7.8 s (205 tok/s); 32 slots with the shared system prompt at p50 1.5 s /
+p99 2.4 s (655 tok/s), first token at p50 0.85 s.
+
 ## Memory
 
 wasm32 caps linear memory at 4 GiB, and the model weights plus every context's

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/goccy/go-llama
 
 go 1.25.0
 
-require github.com/goccy/llamawasm2go v0.3.5
+require github.com/goccy/llamawasm2go v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/goccy/llamawasm2go v0.3.5 h1:vT1FSAb1e5gJXOTQoCaC+es5PAWcLoxlMX1Nln5rt9c=
-github.com/goccy/llamawasm2go v0.3.5/go.mod h1:2RraXBB/RS2RBlIol/M/rNvIcdtatKWzt8g7q63MPm0=
+github.com/goccy/llamawasm2go v0.4.0 h1:RaS1ILM9yvGWDeeOwp5Kwd8che94R5774CrYI2OYEXU=
+github.com/goccy/llamawasm2go v0.4.0/go.mod h1:2RraXBB/RS2RBlIol/M/rNvIcdtatKWzt8g7q63MPm0=

--- a/internal/engine.go
+++ b/internal/engine.go
@@ -45,6 +45,10 @@ const (
 	midCtxReset
 	midCtxScore
 	midCtxScoreChoices
+	midCtxSlotsCancel
+	midCtxSlotsPost
+	midCtxSlotsStatus
+	midCtxSlotsUpdate
 	midCtxStateLoad
 	midCtxStateSave
 	midDetokenize
@@ -82,22 +86,26 @@ var invokers = [midCount]func(*base.Module, wptr, wptr) (int64, error){
 	midCtxReset:               wasm2go.Inv_0_11,
 	midCtxScore:               wasm2go.Inv_0_12,
 	midCtxScoreChoices:        wasm2go.Inv_0_13,
-	midCtxStateLoad:           wasm2go.Inv_0_14,
-	midCtxStateSave:           wasm2go.Inv_0_15,
-	midDetokenize:             wasm2go.Inv_0_16,
-	midLoraFree:               wasm2go.Inv_0_17,
-	midLoraLoad:               wasm2go.Inv_0_18,
-	midModelFree:              wasm2go.Inv_0_19,
-	midModelInfo:              wasm2go.Inv_0_20,
-	midModelLoad:              wasm2go.Inv_0_21,
-	midModelLoadProgressAddr:  wasm2go.Inv_0_22,
-	midModelTensors:           wasm2go.Inv_0_23,
-	midTokenToPiece:           wasm2go.Inv_0_24,
-	midTokenize:               wasm2go.Inv_0_25,
-	midWasmBuildInfo:          wasm2go.Inv_0_26,
-	midWasmFree:               wasm2go.Inv_0_27,
-	midWasmInit:               wasm2go.Inv_0_28,
-	midWasmLastError:          wasm2go.Inv_0_29,
+	midCtxSlotsCancel:         wasm2go.Inv_0_14,
+	midCtxSlotsPost:           wasm2go.Inv_0_15,
+	midCtxSlotsStatus:         wasm2go.Inv_0_16,
+	midCtxSlotsUpdate:         wasm2go.Inv_0_17,
+	midCtxStateLoad:           wasm2go.Inv_0_18,
+	midCtxStateSave:           wasm2go.Inv_0_19,
+	midDetokenize:             wasm2go.Inv_0_20,
+	midLoraFree:               wasm2go.Inv_0_21,
+	midLoraLoad:               wasm2go.Inv_0_22,
+	midModelFree:              wasm2go.Inv_0_23,
+	midModelInfo:              wasm2go.Inv_0_24,
+	midModelLoad:              wasm2go.Inv_0_25,
+	midModelLoadProgressAddr:  wasm2go.Inv_0_26,
+	midModelTensors:           wasm2go.Inv_0_27,
+	midTokenToPiece:           wasm2go.Inv_0_28,
+	midTokenize:               wasm2go.Inv_0_29,
+	midWasmBuildInfo:          wasm2go.Inv_0_30,
+	midWasmFree:               wasm2go.Inv_0_31,
+	midWasmInit:               wasm2go.Inv_0_32,
+	midWasmLastError:          wasm2go.Inv_0_33,
 }
 
 // NewEngine brings up an independent engine instance: its own wasm module
@@ -461,6 +469,49 @@ func (m *Module) LlamaCtxScoreChoices(ctx uint64, choices string, choicesLen uin
 	buf = pbAppendString(buf, 2, choices)
 	buf = pbAppendUint64(buf, 3, uint64(choicesLen))
 	resp, err := m.invokeMethod(midCtxScoreChoices, buf)
+	if err != nil {
+		return "", err
+	}
+	return readScalarAtField(resp, 1, (*pbReader).readString), nil
+}
+
+func (m *Module) LlamaCtxSlotsPost(ctx uint64, task string, taskLen uint32) (string, error) {
+	buf := pbNewBuf()
+	buf = pbAppendUint64(buf, 1, ctx)
+	buf = pbAppendString(buf, 2, task)
+	buf = pbAppendUint64(buf, 3, uint64(taskLen))
+	resp, err := m.invokeMethod(midCtxSlotsPost, buf)
+	if err != nil {
+		return "", err
+	}
+	return readScalarAtField(resp, 1, (*pbReader).readString), nil
+}
+
+func (m *Module) LlamaCtxSlotsUpdate(ctx uint64) (string, error) {
+	buf := pbNewBuf()
+	buf = pbAppendUint64(buf, 1, ctx)
+	resp, err := m.invokeMethod(midCtxSlotsUpdate, buf)
+	if err != nil {
+		return "", err
+	}
+	return readScalarAtField(resp, 1, (*pbReader).readString), nil
+}
+
+func (m *Module) LlamaCtxSlotsCancel(ctx uint64, id int32) (string, error) {
+	buf := pbNewBuf()
+	buf = pbAppendUint64(buf, 1, ctx)
+	buf = pbAppendInt32(buf, 2, id)
+	resp, err := m.invokeMethod(midCtxSlotsCancel, buf)
+	if err != nil {
+		return "", err
+	}
+	return readScalarAtField(resp, 1, (*pbReader).readString), nil
+}
+
+func (m *Module) LlamaCtxSlotsStatus(ctx uint64) (string, error) {
+	buf := pbNewBuf()
+	buf = pbAppendUint64(buf, 1, ctx)
+	resp, err := m.invokeMethod(midCtxSlotsStatus, buf)
 	if err != nil {
 		return "", err
 	}

--- a/internal/engine.go
+++ b/internal/engine.go
@@ -48,6 +48,7 @@ const (
 	midCtxSlotsCancel
 	midCtxSlotsPost
 	midCtxSlotsStatus
+	midCtxSlotsSystemPrompt
 	midCtxSlotsUpdate
 	midCtxStateLoad
 	midCtxStateSave
@@ -89,23 +90,24 @@ var invokers = [midCount]func(*base.Module, wptr, wptr) (int64, error){
 	midCtxSlotsCancel:         wasm2go.Inv_0_14,
 	midCtxSlotsPost:           wasm2go.Inv_0_15,
 	midCtxSlotsStatus:         wasm2go.Inv_0_16,
-	midCtxSlotsUpdate:         wasm2go.Inv_0_17,
-	midCtxStateLoad:           wasm2go.Inv_0_18,
-	midCtxStateSave:           wasm2go.Inv_0_19,
-	midDetokenize:             wasm2go.Inv_0_20,
-	midLoraFree:               wasm2go.Inv_0_21,
-	midLoraLoad:               wasm2go.Inv_0_22,
-	midModelFree:              wasm2go.Inv_0_23,
-	midModelInfo:              wasm2go.Inv_0_24,
-	midModelLoad:              wasm2go.Inv_0_25,
-	midModelLoadProgressAddr:  wasm2go.Inv_0_26,
-	midModelTensors:           wasm2go.Inv_0_27,
-	midTokenToPiece:           wasm2go.Inv_0_28,
-	midTokenize:               wasm2go.Inv_0_29,
-	midWasmBuildInfo:          wasm2go.Inv_0_30,
-	midWasmFree:               wasm2go.Inv_0_31,
-	midWasmInit:               wasm2go.Inv_0_32,
-	midWasmLastError:          wasm2go.Inv_0_33,
+	midCtxSlotsSystemPrompt:   wasm2go.Inv_0_17,
+	midCtxSlotsUpdate:         wasm2go.Inv_0_18,
+	midCtxStateLoad:           wasm2go.Inv_0_19,
+	midCtxStateSave:           wasm2go.Inv_0_20,
+	midDetokenize:             wasm2go.Inv_0_21,
+	midLoraFree:               wasm2go.Inv_0_22,
+	midLoraLoad:               wasm2go.Inv_0_23,
+	midModelFree:              wasm2go.Inv_0_24,
+	midModelInfo:              wasm2go.Inv_0_25,
+	midModelLoad:              wasm2go.Inv_0_26,
+	midModelLoadProgressAddr:  wasm2go.Inv_0_27,
+	midModelTensors:           wasm2go.Inv_0_28,
+	midTokenToPiece:           wasm2go.Inv_0_29,
+	midTokenize:               wasm2go.Inv_0_30,
+	midWasmBuildInfo:          wasm2go.Inv_0_31,
+	midWasmFree:               wasm2go.Inv_0_32,
+	midWasmInit:               wasm2go.Inv_0_33,
+	midWasmLastError:          wasm2go.Inv_0_34,
 }
 
 // NewEngine brings up an independent engine instance: its own wasm module
@@ -502,6 +504,18 @@ func (m *Module) LlamaCtxSlotsCancel(ctx uint64, id int32) (string, error) {
 	buf = pbAppendUint64(buf, 1, ctx)
 	buf = pbAppendInt32(buf, 2, id)
 	resp, err := m.invokeMethod(midCtxSlotsCancel, buf)
+	if err != nil {
+		return "", err
+	}
+	return readScalarAtField(resp, 1, (*pbReader).readString), nil
+}
+
+func (m *Module) LlamaCtxSlotsSystemPrompt(ctx uint64, text string, textLen uint32) (string, error) {
+	buf := pbNewBuf()
+	buf = pbAppendUint64(buf, 1, ctx)
+	buf = pbAppendString(buf, 2, text)
+	buf = pbAppendUint64(buf, 3, uint64(textLen))
+	resp, err := m.invokeMethod(midCtxSlotsSystemPrompt, buf)
 	if err != nil {
 		return "", err
 	}

--- a/internal/gemv_repack_numeric_test.go
+++ b/internal/gemv_repack_numeric_test.go
@@ -26,7 +26,7 @@ import (
 // recorded in the llama-wasm release build log); it moves with any
 // engine rebuild, so re-read it from the log (or the bundle's
 // load32_splat memarg offsets) when bumping the bundle dependency.
-const repackF16Table = 8794144
+const repackF16Table = 8795968
 
 func f16Bits(f float32) uint16 {
 	// Exact for the small power-of-two scales the tests use.

--- a/internal/llama.go
+++ b/internal/llama.go
@@ -1065,8 +1065,8 @@ func LlamaCtxFree(ctx uint64) error {
 
 // Run generation and return JSON:
 //
-//	{"ok":true,"text":"...","tokens":[..],"n_prompt":N,"n_cached":N,
-//	 "n_decoded":N,
+//	{"ok":true,"text":"...","b64":"...","tokens":[..],"n_prompt":N,
+//	 "n_cached":N,"n_decoded":N,
 //	 "stop_reason":"eos"|"length"|"stop"|"interrupted","interrupted":bool,
 //	 "timings":{"prompt_ms":f,"decode_ms":f}}
 //
@@ -1170,6 +1170,14 @@ func LlamaCtxLoraSet(ctx uint64, adaptersJson string, adaptersJsonLen uint32) (s
 //	n_ctx           0 = the model's training context length
 //	n_batch         logical batch size
 //	n_ubatch        physical batch size
+//	n_seq_max       sequences the context holds at once (default 1)
+//	kv_unified      non-zero: the sequences share one KV buffer of n_ctx
+//	                cells (llama_memory_seq_cp is then metadata, not a copy,
+//	                which the batched llama_ctx_score_choices and a shared
+//	                prompt prefix across slots lean on); zero (llama.cpp's
+//	                default) gives each sequence its own stream of
+//	                n_ctx / n_seq_max cells, cheaper attention for
+//	                independent sequences
 //	n_threads       0 = 1; a single-threaded wasm build clamps to 1
 //	embeddings      non-zero puts the context in embedding mode
 //	rope_freq_base  RoPE base frequency override (0 = model default)
@@ -1239,6 +1247,112 @@ func LlamaCtxScoreChoices(ctx uint64, choices string, choicesLen uint32) (string
 	return readScalarAtField(resp, 1, (*pbReader).readString), nil
 }
 
+// Drop a task. A queued task is removed silently (`{"ok":true,"queued":true}`);
+// a busy one releases its slot and returns `{"ok":true,"queued":false,
+// "final":{...}}` with stop_reason "interrupted", the text produced so far
+// included. An unknown id is an error.
+func LlamaCtxSlotsCancel(ctx uint64, id int32) (string, error) {
+	buf := pbNewBuf()
+	buf = pbAppendUint64(buf, 1, ctx)
+	buf = pbAppendInt32(buf, 2, id)
+	resp, err := invokeMethod(0, 14, buf, wasm2go.Inv_0_14)
+	if err != nil {
+		return "", err
+	}
+	return readScalarAtField(resp, 1, (*pbReader).readString), nil
+}
+
+// Continuous batching, after llama.cpp's server: a task is a prompt plus
+// sampling parameters; a slot runs one task on its own KV sequence; one
+// update decodes a single batch drawn from every busy slot and samples each
+// of them. The context must be created with n_seq_max = the number of slots
+// (see llama_ctx_new's kv_unified for how they share the cache). While slots hold
+// tasks the single-sequence entry points (generate, score, eval, embed,
+// state save/load) refuse to run; llama_ctx_reset drops every task.
+//
+// llama_ctx_slots_post queues a task. `task_json` is llama_ctx_generate's
+// params object plus a "prompt" string (cache_prompt is rejected; every
+// task decodes its own sequence). The prompt is tokenized with
+// add_special=true. A task whose prompt plus n_predict does not fit a
+// sequence's window (n_ctx with kv_unified, n_ctx / n_seq_max without) is
+// refused; n_predict -1 means the rest of the window. With kv_unified the
+// busy slots also share the buffer, so a task launches only when its prompt
+// plus n_predict fit next to what they may still write. Returns
+// `{"ok":true,"id":N}`; ids start at 1.
+func LlamaCtxSlotsPost(ctx uint64, taskJson string, taskJsonLen uint32) (string, error) {
+	buf := pbNewBuf()
+	buf = pbAppendUint64(buf, 1, ctx)
+	buf = pbAppendString(buf, 2, taskJson)
+	buf = pbAppendUint64(buf, 3, uint64(taskJsonLen))
+	resp, err := invokeMethod(0, 15, buf, wasm2go.Inv_0_15)
+	if err != nil {
+		return "", err
+	}
+	return readScalarAtField(resp, 1, (*pbReader).readString), nil
+}
+
+// `{"ok":true,"n_slots":N,"active":N,"queued":N,"n_ctx":N,"used":N}` —
+// n_slots excludes the sequence a system prompt occupies; used is the
+// cache cells the busy slots hold.
+func LlamaCtxSlotsStatus(ctx uint64) (string, error) {
+	buf := pbNewBuf()
+	buf = pbAppendUint64(buf, 1, ctx)
+	resp, err := invokeMethod(0, 16, buf, wasm2go.Inv_0_16)
+	if err != nil {
+		return "", err
+	}
+	return readScalarAtField(resp, 1, (*pbReader).readString), nil
+}
+
+// The system prompt shared by every task, after llama.cpp's server of old:
+// decoded once into the last sequence, which it then occupies (one slot
+// fewer for tasks), and copied into a task's sequence (llama_memory_seq_cp
+// — metadata with kv_unified, a cell copy otherwise) whenever the task's
+// prompt starts with the same tokens, so only the rest is decoded; the
+// final's n_cached counts the reused tokens. Tokenized with
+// add_special=true, so a task prompt should be the system prompt text
+// followed by the rest. Refused while slots hold tasks; an empty text
+// clears it and frees the sequence. Returns `{"ok":true,"n_tokens":N}`.
+func LlamaCtxSlotsSystemPrompt(ctx uint64, text string, textLen uint32) (string, error) {
+	buf := pbNewBuf()
+	buf = pbAppendUint64(buf, 1, ctx)
+	buf = pbAppendString(buf, 2, text)
+	buf = pbAppendUint64(buf, 3, uint64(textLen))
+	resp, err := invokeMethod(0, 17, buf, wasm2go.Inv_0_17)
+	if err != nil {
+		return "", err
+	}
+	return readScalarAtField(resp, 1, (*pbReader).readString), nil
+}
+
+// One scheduling step. Queued tasks are launched into idle slots, in order,
+// while the head of the queue fits the cells the busy slots may still
+// write. Then one batch is assembled — the pending token of every
+// generating slot, then prompt chunks of the slots still decoding their
+// prompt, up to n_batch tokens — decoded once, and every slot whose logits
+// it carried is sampled. Returns
+//
+//	{"ok":true,"active":N,"queued":N,"events":[
+//	  {"id":N,"token":T,"text":"..","b64":".."},   // one produced token
+//	  {"id":N,"final":{...}},                       // task finished: the
+//	                                                // object llama_ctx_generate
+//	                                                // returns (n_cached is 0)
+//	  {"id":N,"error":"..."}]}                      // task failed
+//
+// A task's last event is its final or its error. With no busy slot and an
+// empty queue the call decodes nothing and returns no events. A stop
+// string is delivered as it is decoded and trimmed from the final text,
+// as in llama_ctx_generate.
+func LlamaCtxSlotsUpdate(ctx uint64) (string, error) {
+	buf := pbNewBuf()
+	buf = pbAppendUint64(buf, 1, ctx)
+	resp, err := invokeMethod(0, 18, buf, wasm2go.Inv_0_18)
+	if err != nil {
+		return "", err
+	}
+	return readScalarAtField(resp, 1, (*pbReader).readString), nil
+}
+
 // Restore a context state previously produced by llama_ctx_state_save.
 // `data` carries the serialized bytes (the bridge copies them into
 // linear memory; they may contain NUL bytes). A blob from this bridge also
@@ -1250,7 +1364,7 @@ func LlamaCtxStateLoad(ctx uint64, data string, size uint32) (string, error) {
 	buf = pbAppendUint64(buf, 1, ctx)
 	buf = pbAppendString(buf, 2, data)
 	buf = pbAppendUint64(buf, 3, uint64(size))
-	resp, err := invokeMethod(0, 14, buf, wasm2go.Inv_0_14)
+	resp, err := invokeMethod(0, 19, buf, wasm2go.Inv_0_19)
 	if err != nil {
 		return "", err
 	}
@@ -1266,7 +1380,7 @@ func LlamaCtxStateLoad(ctx uint64, data string, size uint32) (string, error) {
 func LlamaCtxStateSave(ctx uint64) (string, error) {
 	buf := pbNewBuf()
 	buf = pbAppendUint64(buf, 1, ctx)
-	resp, err := invokeMethod(0, 15, buf, wasm2go.Inv_0_15)
+	resp, err := invokeMethod(0, 20, buf, wasm2go.Inv_0_20)
 	if err != nil {
 		return "", err
 	}
@@ -1274,14 +1388,16 @@ func LlamaCtxStateSave(ctx uint64) (string, error) {
 }
 
 // Render tokens (a JSON array of ints) back to text:
-// `{"ok":true,"text":"..."}`.
+// `{"ok":true,"text":"...","b64":"..."}`. `b64` is the same bytes base64
+// encoded: byte-level tokens can render to a partial UTF-8 sequence, which a
+// JSON string cannot carry losslessly (decoders substitute U+FFFD).
 func LlamaDetokenize(model uint64, tokensJson string, tokensJsonLen uint32, renderSpecial int32) (string, error) {
 	buf := pbNewBuf()
 	buf = pbAppendUint64(buf, 1, model)
 	buf = pbAppendString(buf, 2, tokensJson)
 	buf = pbAppendUint64(buf, 3, uint64(tokensJsonLen))
 	buf = pbAppendInt32(buf, 4, renderSpecial)
-	resp, err := invokeMethod(0, 16, buf, wasm2go.Inv_0_16)
+	resp, err := invokeMethod(0, 21, buf, wasm2go.Inv_0_21)
 	if err != nil {
 		return "", err
 	}
@@ -1293,7 +1409,7 @@ func LlamaDetokenize(model uint64, tokensJson string, tokensJsonLen uint32, rend
 func LlamaLoraFree(adapter uint64) error {
 	buf := pbNewBuf()
 	buf = pbAppendUint64(buf, 1, adapter)
-	_, err := invokeMethod(0, 17, buf, wasm2go.Inv_0_17)
+	_, err := invokeMethod(0, 22, buf, wasm2go.Inv_0_22)
 	return err
 }
 
@@ -1304,7 +1420,7 @@ func LlamaLoraLoad(model uint64, path string, pathLen uint32) (uint64, error) {
 	buf = pbAppendUint64(buf, 1, model)
 	buf = pbAppendString(buf, 2, path)
 	buf = pbAppendUint64(buf, 3, uint64(pathLen))
-	resp, err := invokeMethod(0, 18, buf, wasm2go.Inv_0_18)
+	resp, err := invokeMethod(0, 23, buf, wasm2go.Inv_0_23)
 	if err != nil {
 		return 0, err
 	}
@@ -1315,7 +1431,7 @@ func LlamaLoraLoad(model uint64, path string, pathLen uint32) (uint64, error) {
 func LlamaModelFree(model uint64) error {
 	buf := pbNewBuf()
 	buf = pbAppendUint64(buf, 1, model)
-	_, err := invokeMethod(0, 19, buf, wasm2go.Inv_0_19)
+	_, err := invokeMethod(0, 24, buf, wasm2go.Inv_0_24)
 	return err
 }
 
@@ -1325,7 +1441,7 @@ func LlamaModelFree(model uint64) error {
 func LlamaModelInfo(model uint64) (string, error) {
 	buf := pbNewBuf()
 	buf = pbAppendUint64(buf, 1, model)
-	resp, err := invokeMethod(0, 20, buf, wasm2go.Inv_0_20)
+	resp, err := invokeMethod(0, 25, buf, wasm2go.Inv_0_25)
 	if err != nil {
 		return "", err
 	}
@@ -1347,7 +1463,7 @@ func LlamaModelLoad(path string, pathLen uint32, nGpuLayers int32, useMmap int32
 	buf = pbAppendUint64(buf, 2, uint64(pathLen))
 	buf = pbAppendInt32(buf, 3, nGpuLayers)
 	buf = pbAppendInt32(buf, 4, useMmap)
-	resp, err := invokeMethod(0, 21, buf, wasm2go.Inv_0_21)
+	resp, err := invokeMethod(0, 26, buf, wasm2go.Inv_0_26)
 	if err != nil {
 		return 0, err
 	}
@@ -1359,7 +1475,7 @@ func LlamaModelLoad(path string, pathLen uint32, nGpuLayers int32, useMmap int32
 // a progress bar. Valid for the lifetime of the wasm instance.
 func LlamaModelLoadProgressAddr() (uint64, error) {
 	buf := pbNewBuf()
-	resp, err := invokeMethod(0, 22, buf, wasm2go.Inv_0_22)
+	resp, err := invokeMethod(0, 27, buf, wasm2go.Inv_0_27)
 	if err != nil {
 		return 0, err
 	}
@@ -1376,22 +1492,23 @@ func LlamaModelLoadProgressAddr() (uint64, error) {
 func LlamaModelTensors(model uint64) (string, error) {
 	buf := pbNewBuf()
 	buf = pbAppendUint64(buf, 1, model)
-	resp, err := invokeMethod(0, 23, buf, wasm2go.Inv_0_23)
+	resp, err := invokeMethod(0, 28, buf, wasm2go.Inv_0_28)
 	if err != nil {
 		return "", err
 	}
 	return readScalarAtField(resp, 1, (*pbReader).readString), nil
 }
 
-// The text piece a single token renders to, as JSON `{"ok":true,"text":".."}`.
-// Byte-level tokens can render to invalid UTF-8 on their own; the caller is
+// The text piece a single token renders to, as JSON
+// `{"ok":true,"text":"..","b64":".."}`. Byte-level tokens can render to
+// invalid UTF-8 on their own; `b64` carries the exact bytes and the caller is
 // expected to accumulate pieces.
 func LlamaTokenToPiece(model uint64, token int32, renderSpecial int32) (string, error) {
 	buf := pbNewBuf()
 	buf = pbAppendUint64(buf, 1, model)
 	buf = pbAppendInt32(buf, 2, token)
 	buf = pbAppendInt32(buf, 3, renderSpecial)
-	resp, err := invokeMethod(0, 24, buf, wasm2go.Inv_0_24)
+	resp, err := invokeMethod(0, 29, buf, wasm2go.Inv_0_29)
 	if err != nil {
 		return "", err
 	}
@@ -1408,7 +1525,7 @@ func LlamaTokenize(model uint64, text string, textLen uint32, addSpecial int32, 
 	buf = pbAppendUint64(buf, 3, uint64(textLen))
 	buf = pbAppendInt32(buf, 4, addSpecial)
 	buf = pbAppendInt32(buf, 5, parseSpecial)
-	resp, err := invokeMethod(0, 25, buf, wasm2go.Inv_0_25)
+	resp, err := invokeMethod(0, 30, buf, wasm2go.Inv_0_30)
 	if err != nil {
 		return "", err
 	}
@@ -1419,7 +1536,7 @@ func LlamaTokenize(model uint64, text string, textLen uint32, addSpecial int32, 
 // and whether this wasm was built with SIMD / threads. Diagnostics only.
 func LlamaWasmBuildInfo() (string, error) {
 	buf := pbNewBuf()
-	resp, err := invokeMethod(0, 26, buf, wasm2go.Inv_0_26)
+	resp, err := invokeMethod(0, 31, buf, wasm2go.Inv_0_31)
 	if err != nil {
 		return "", err
 	}
@@ -1429,7 +1546,7 @@ func LlamaWasmBuildInfo() (string, error) {
 // Free process-wide backend state. After this every handle is invalid.
 func LlamaWasmFree() error {
 	buf := pbNewBuf()
-	_, err := invokeMethod(0, 27, buf, wasm2go.Inv_0_27)
+	_, err := invokeMethod(0, 32, buf, wasm2go.Inv_0_32)
 	return err
 }
 
@@ -1437,7 +1554,7 @@ func LlamaWasmFree() error {
 // llama_model_load, so an embedder normally never calls it.
 func LlamaWasmInit() error {
 	buf := pbNewBuf()
-	_, err := invokeMethod(0, 28, buf, wasm2go.Inv_0_28)
+	_, err := invokeMethod(0, 33, buf, wasm2go.Inv_0_33)
 	return err
 }
 
@@ -1446,7 +1563,7 @@ func LlamaWasmInit() error {
 // this exists for the handle-returning calls, which can only signal 0.
 func LlamaWasmLastError() (string, error) {
 	buf := pbNewBuf()
-	resp, err := invokeMethod(0, 29, buf, wasm2go.Inv_0_29)
+	resp, err := invokeMethod(0, 34, buf, wasm2go.Inv_0_34)
 	if err != nil {
 		return "", err
 	}

--- a/llama.go
+++ b/llama.go
@@ -203,13 +203,23 @@ type ContextParams struct {
 	// threads-enabled build (BuildInfo.Threads); the single-threaded wasm
 	// clamps to 1.
 	NThreads uint32
-	// NSeqMax is the number of sequences the context can hold at once. A
-	// value > 1 turns on the unified KV cache: NCtx stays the TOTAL cell
-	// budget shared by every sequence, and ScoreChoices batches its
-	// teacher-forced candidates into one decode (one sequence per candidate,
-	// all sharing the stem). Zero or 1 keeps the single-sequence default,
-	// where ScoreChoices decodes candidates one at a time.
+	// NSeqMax is the number of sequences the context can hold at once: the
+	// slots of a Slots, or the candidates ScoreChoices decodes in one batch
+	// (one sequence per candidate, all sharing the stem). Zero or 1 is the
+	// single-sequence default, where ScoreChoices decodes candidates one at
+	// a time.
 	NSeqMax uint32
+	// KVUnified chooses how the NSeqMax sequences share the KV cache, as
+	// llama.cpp's kv_unified does. False, the default, gives each sequence
+	// its own stream of NCtx / NSeqMax cells: attention over a sequence then
+	// costs only its own cells, which is what independent tasks on a Slots
+	// want. True shares one buffer of NCtx cells across the sequences, where
+	// copying a sequence is metadata rather than a copy: what ScoreChoices'
+	// batched path leans on (its candidates all share the stem), and what a
+	// prompt prefix shared across slots needs. The measured difference for
+	// 64 independent tasks was 903 vs 500 tok/s in favour of streams; for
+	// ScoreChoices with NSeqMax > 1, set it.
+	KVUnified bool
 	// Embeddings puts the context in embedding mode, which Context.Embed
 	// requires and which disables generation.
 	Embeddings bool
@@ -228,6 +238,7 @@ type ctxRequest struct {
 	NUBatch       uint32  `json:"n_ubatch,omitempty"`
 	NThreads      uint32  `json:"n_threads,omitempty"`
 	NSeqMax       uint32  `json:"n_seq_max,omitempty"`
+	KVUnified     int32   `json:"kv_unified,omitempty"`
 	Embeddings    int     `json:"embeddings,omitempty"`
 	RopeFreqBase  float32 `json:"rope_freq_base,omitempty"`
 	RopeFreqScale float32 `json:"rope_freq_scale,omitempty"`
@@ -529,6 +540,7 @@ func (m *Model) NewContext(p ContextParams) (*Context, error) {
 		NUBatch:       p.NUBatch,
 		NThreads:      p.NThreads,
 		NSeqMax:       p.NSeqMax,
+		KVUnified:     b2i(p.KVUnified),
 		Embeddings:    int(b2i(p.Embeddings)),
 		RopeFreqBase:  p.RopeFreqBase,
 		RopeFreqScale: p.RopeFreqScale,

--- a/llama.go
+++ b/llama.go
@@ -417,25 +417,7 @@ func (m *Model) TokenToPiece(token int32, renderSpecial bool) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	var out struct {
-		envelope
-		Text string `json:"text"`
-		B64  string `json:"b64"`
-	}
-	if err := decode("token_to_piece", js, &out); err != nil {
-		return "", err
-	}
-	// A byte-fallback token holds a partial UTF-8 sequence, which the JSON
-	// text field cannot carry losslessly; the base64 field carries the raw
-	// bytes exactly as llama.cpp's llama_token_to_piece returns them.
-	if out.B64 != "" {
-		raw, err := base64.StdEncoding.DecodeString(out.B64)
-		if err != nil {
-			return "", fmt.Errorf("token_to_piece: bad b64 payload: %w", err)
-		}
-		return string(raw), nil
-	}
-	return out.Text, nil
+	return decodeText("token_to_piece", js)
 }
 
 // ApplyChatTemplate renders messages into a prompt with the model's chat
@@ -624,10 +606,18 @@ func (c *Context) GenerateWithDraft(draft *Context, prompt string, p Params, nDr
 	var out struct {
 		envelope
 		Result
+		B64 string `json:"b64"`
 	}
 	if err := decode("generate", js, &out); err != nil {
 		return Result{}, err
 	}
+	// Result.Text must be the bytes the token sink saw, not a U+FFFD-patched
+	// rendering of them; see decodeText.
+	text, err := textFields{Text: out.Text, B64: out.B64}.bytes("generate")
+	if err != nil {
+		return Result{}, err
+	}
+	out.Result.Text = text
 	return out.Result, nil
 }
 
@@ -855,10 +845,18 @@ func (c *Context) generate(prompt string, req genRequest, sink bridge.Token_Sink
 	var out struct {
 		envelope
 		Result
+		B64 string `json:"b64"`
 	}
 	if err := decode("generate", js, &out); err != nil {
 		return Result{}, err
 	}
+	// Result.Text must be the bytes the token sink saw, not a U+FFFD-patched
+	// rendering of them; see decodeText.
+	text, err := textFields{Text: out.Text, B64: out.B64}.bytes("generate")
+	if err != nil {
+		return Result{}, err
+	}
+	out.Result.Text = text
 	return out.Result, nil
 }
 
@@ -884,14 +882,41 @@ func decode(what, js string, v enveloped) error {
 	return v.err(what)
 }
 
-// decodeText is the common shape of the calls that return just a string.
+// decodeText is the common shape of the calls that return model-produced
+// bytes: a "text" field plus a "b64" copy of the same bytes.
+//
+// Tokenizers are byte-level, so a piece can be a partial UTF-8 sequence (see
+// utf8.go). The JSON text field cannot carry that losslessly — encoding/json
+// replaces invalid UTF-8 with U+FFFD — while the token-sink callback hands
+// Stream the raw bytes; b64 carries them exactly, so Result.Text and the
+// streamed pieces agree byte for byte. text alone is accepted for bridges
+// that predate the b64 field.
 func decodeText(what, js string) (string, error) {
 	var out struct {
 		envelope
-		Text string `json:"text"`
+		textFields
 	}
 	if err := decode(what, js, &out); err != nil {
 		return "", err
 	}
-	return out.Text, nil
+	return out.textFields.bytes(what)
+}
+
+// textFields is the text-plus-b64 pair every bridge result that carries
+// model-produced bytes uses.
+type textFields struct {
+	Text string `json:"text"`
+	B64  string `json:"b64"`
+}
+
+// bytes returns the raw bytes: the b64 field when present, else the text.
+func (t textFields) bytes(what string) (string, error) {
+	if t.B64 == "" {
+		return t.Text, nil
+	}
+	raw, err := base64.StdEncoding.DecodeString(t.B64)
+	if err != nil {
+		return "", fmt.Errorf("llama: %s: bad b64 payload: %w", what, err)
+	}
+	return string(raw), nil
 }

--- a/llama_test.go
+++ b/llama_test.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 	"testing"
 	"time"
+	"unicode/utf8"
 
 	llama "github.com/goccy/go-llama"
 )
@@ -248,9 +249,17 @@ func TestStreamDeliversTextWhileGenerating(t *testing.T) {
 		t.Errorf("streamed text differs from the returned text:\n stream: %q\n return: %q", got.String(), res.Text)
 	}
 	// One callback per decoded token, so delivery is genuinely incremental
-	// rather than one dump at the end.
-	if len(pieces) != res.NDecoded {
-		t.Errorf("expected one piece per decoded token: %d pieces, %d tokens", len(pieces), res.NDecoded)
+	// rather than one dump at the end. A token that ends part-way through a
+	// multi-byte character is held back and delivered together with the token
+	// that completes it (see utf8.go), so a piece may cover more than one
+	// token, but never fewer.
+	if len(pieces) > res.NDecoded || len(pieces) < 2 {
+		t.Errorf("expected about one piece per decoded token: %d pieces, %d tokens", len(pieces), res.NDecoded)
+	}
+	for i, p := range pieces[:len(pieces)-1] {
+		if !utf8.ValidString(p) && utf8.ValidString(got.String()) {
+			t.Errorf("piece %d %q is not valid UTF-8 although the whole text is: a character was split across callbacks", i, p)
+		}
 	}
 	if res.NDecoded != want {
 		t.Errorf("expected %d tokens, got %d", want, res.NDecoded)
@@ -259,6 +268,60 @@ func TestStreamDeliversTextWhileGenerating(t *testing.T) {
 		t.Errorf("first piece arrived at %v, at the very end of a %v generation", firstAt, total)
 	}
 	t.Logf("%d pieces, first after %v, total %v", len(pieces), firstAt, total)
+}
+
+// A byte-level tokenizer has tokens that render to a single byte >= 0x80: not
+// valid UTF-8 on their own. Detokenize must return exactly those bytes, the
+// same way TokenToPiece and Stream's callback do, rather than a U+FFFD
+// rendering of them.
+func TestDetokenizeKeepsPartialUTF8(t *testing.T) {
+	m := load(t)
+	var (
+		byteTok   int32 = -1
+		bytePiece string
+	)
+	for tok := int32(0); tok < 4096 && byteTok < 0; tok++ {
+		piece, err := m.TokenToPiece(tok, false)
+		if err != nil {
+			t.Fatalf("TokenToPiece(%d): %v", tok, err)
+		}
+		if len(piece) == 1 && piece[0] >= 0x80 {
+			byteTok, bytePiece = tok, piece
+		}
+	}
+	if byteTok < 0 {
+		t.Skip("no byte-fallback token among the first 4096 tokens of this vocabulary")
+	}
+	got, err := m.Detokenize([]int32{byteTok}, false)
+	if err != nil {
+		t.Fatalf("Detokenize: %v", err)
+	}
+	if got != bytePiece {
+		t.Errorf("Detokenize(%d) = %q, want the raw byte %q", byteTok, got, bytePiece)
+	}
+	// Two byte tokens forming one character must come back as that character.
+	half1, half2 := int32(-1), int32(-1)
+	for tok := int32(0); tok < 4096 && (half1 < 0 || half2 < 0); tok++ {
+		piece, err := m.TokenToPiece(tok, false)
+		if err != nil {
+			t.Fatalf("TokenToPiece(%d): %v", tok, err)
+		}
+		if len(piece) == 1 && piece[0] == 0xC3 {
+			half1 = tok
+		}
+		if len(piece) == 1 && piece[0] == 0xA9 {
+			half2 = tok
+		}
+	}
+	if half1 >= 0 && half2 >= 0 {
+		got, err := m.Detokenize([]int32{half1, half2}, false)
+		if err != nil {
+			t.Fatalf("Detokenize: %v", err)
+		}
+		if got != "\u00e9" {
+			t.Errorf("Detokenize(0xC3, 0xA9) = %q, want %q", got, "\u00e9")
+		}
+	}
 }
 
 func TestStreamNilCallbackMatchesGenerate(t *testing.T) {

--- a/scorechoices_test.go
+++ b/scorechoices_test.go
@@ -167,7 +167,7 @@ func TestScoreChoicesSeqBatched(t *testing.T) {
 
 	// NSeqMax 4 forces chunking (8 multi-token candidates over 3 spare
 	// sequences per group).
-	bat, err := m.NewContext(llama.ContextParams{NCtx: 256, NSeqMax: 4})
+	bat, err := m.NewContext(llama.ContextParams{NCtx: 256, NSeqMax: 4, KVUnified: true})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/slots.go
+++ b/slots.go
@@ -142,6 +142,36 @@ func (s *Slots) Post(ctx context.Context, task Task) (*TaskCompletion, error) {
 	return t, nil
 }
 
+// SetSystemPrompt decodes text once and shares its KV cells with every task
+// whose prompt starts with it, so such a task decodes only the rest (its
+// Result.NCached counts the reused tokens). This is the system prompt of
+// llama.cpp's server of old: it occupies one of the context's sequences,
+// leaving NSeqMax-1 slots for tasks, and with KVUnified the sharing is free
+// (a copy is metadata); without it each task copies the cells, still far
+// cheaper than decoding them. The text is tokenized on its own, so a task's
+// prompt should be exactly this text followed by the rest; a prompt that
+// tokenizes differently at the boundary simply decodes in full. Refused
+// while tasks are held; an empty text clears it.
+func (s *Slots) SetSystemPrompt(text string) error {
+	if err := s.c.use("slots system prompt"); err != nil {
+		return err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.closed {
+		return ErrSlotsClosed
+	}
+	js, err := s.c.model.inst.e().LlamaCtxSlotsSystemPrompt(s.c.h, text, uint32(len(text)))
+	if err != nil {
+		return err
+	}
+	var out struct {
+		envelope
+		NTokens int `json:"n_tokens"`
+	}
+	return decode("slots system prompt", js, &out)
+}
+
 // Status reports the slots, the tasks and the cache cells in use.
 func (s *Slots) Status() (SlotsStatus, error) {
 	if err := s.c.use("slots status"); err != nil {

--- a/slots.go
+++ b/slots.go
@@ -1,0 +1,431 @@
+package llama
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"iter"
+	"sync"
+)
+
+// Task is what a Slots runs: a prompt with its sampling parameters. It is a
+// plain value — Post does not modify it, and the same Task can be posted any
+// number of times. Params.CachePrompt is not available to a task: every task
+// decodes its own sequence.
+type Task struct {
+	Prompt string
+	Params Params
+}
+
+// TaskOutput is one produced token: its id and the text it renders to. The
+// texts of a task's outputs concatenate to the Text of its Result, except
+// that a matched stop string is delivered as it is decoded and only
+// afterwards trimmed from the result.
+type TaskOutput struct {
+	Token int32
+	Text  string
+}
+
+// SlotsStatus is a snapshot of a Slots: how many slots there are and how many
+// hold a task, how many tasks wait for one, and how much of the context's KV
+// cache (NCtx cells) the running tasks hold.
+type SlotsStatus struct {
+	NSlots int `json:"n_slots"`
+	Active int `json:"active"`
+	Queued int `json:"queued"`
+	NCtx   int `json:"n_ctx"`
+	Used   int `json:"used"`
+}
+
+// ErrTaskRunning is returned by TaskCompletion.Result while the task has not
+// finished.
+var ErrTaskRunning = errors.New("llama: task is still running")
+
+// ErrSlotsClosed is the error of every task a Slots dropped when it was
+// closed, and of a Post after Close.
+var ErrSlotsClosed = errors.New("llama: slots are closed")
+
+// Slots runs tasks concurrently on one Context — continuous batching, after
+// llama.cpp's server. The context holds as many slots as its
+// ContextParams.NSeqMax, each running one task on its own KV sequence; one
+// scheduling step decodes a single batch drawn from every busy slot, so the
+// slots share the per-step cost instead of each paying it.
+//
+// A posted task waits for a free slot in FIFO order, and for enough free
+// cells in the shared cache: its prompt plus its NPredict must fit next to
+// what the running tasks may still write (an NPredict of zero means "until
+// the context ends", which reserves the whole remainder).
+//
+// While a Slots holds tasks, the single-sequence methods of its Context
+// (Generate, Stream, Score, ScoreChoices, Eval, Embed, SaveState, LoadState)
+// refuse to run; Reset drops every task. Close cancels every task and stops
+// the scheduler; the Context stays usable.
+type Slots struct {
+	c *Context
+
+	// mu serializes every engine call this Slots makes on the context, and
+	// guards tasks and closed.
+	mu     sync.Mutex
+	tasks  map[int]*TaskCompletion
+	closed bool
+
+	wake chan struct{} // nudged by Post: there is something to schedule
+	stop chan struct{} // closed by Close
+	done chan struct{} // closed when the scheduler has returned
+}
+
+// Slots starts a scheduler over the context's slots. The context must have
+// been created with NSeqMax set to the number of slots wanted (1 still
+// works: tasks then run one at a time, each on its own sequence).
+func (c *Context) Slots() (*Slots, error) {
+	if err := c.use("slots"); err != nil {
+		return nil, err
+	}
+	s := &Slots{
+		c:     c,
+		tasks: map[int]*TaskCompletion{},
+		wake:  make(chan struct{}, 1),
+		stop:  make(chan struct{}),
+		done:  make(chan struct{}),
+	}
+	go s.loop()
+	return s, nil
+}
+
+// Post queues task and returns its completion. The task is cancelled when
+// ctx is done: its slot is released, and its completion finishes with the
+// text produced so far, StopInterrupted, and ctx.Err() as the error.
+func (s *Slots) Post(ctx context.Context, task Task) (*TaskCompletion, error) {
+	if err := s.c.use("slots post"); err != nil {
+		return nil, err
+	}
+	if task.Params.CachePrompt {
+		return nil, errors.New("llama: slots post: CachePrompt is not available to a task")
+	}
+	raw, err := json.Marshal(taskRequest{Prompt: task.Prompt, genRequest: task.Params.wire()})
+	if err != nil {
+		return nil, err
+	}
+	s.mu.Lock()
+	if s.closed {
+		s.mu.Unlock()
+		return nil, ErrSlotsClosed
+	}
+	js, err := s.c.model.inst.e().LlamaCtxSlotsPost(s.c.h, string(raw), uint32(len(raw)))
+	if err != nil {
+		s.mu.Unlock()
+		return nil, err
+	}
+	var out struct {
+		envelope
+		ID int `json:"id"`
+	}
+	if err := decode("slots post", js, &out); err != nil {
+		s.mu.Unlock()
+		return nil, err
+	}
+	t := &TaskCompletion{id: out.ID, done: make(chan struct{})}
+	t.cond = sync.NewCond(&t.mu)
+	s.tasks[out.ID] = t
+	s.mu.Unlock()
+	s.nudge()
+	if ctx.Done() != nil {
+		go func() {
+			select {
+			case <-ctx.Done():
+				s.cancel(t, ctx.Err())
+			case <-t.done:
+			}
+		}()
+	}
+	return t, nil
+}
+
+// Status reports the slots, the tasks and the cache cells in use.
+func (s *Slots) Status() (SlotsStatus, error) {
+	if err := s.c.use("slots status"); err != nil {
+		return SlotsStatus{}, err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	js, err := s.c.model.inst.e().LlamaCtxSlotsStatus(s.c.h)
+	if err != nil {
+		return SlotsStatus{}, err
+	}
+	var out struct {
+		envelope
+		SlotsStatus
+	}
+	if err := decode("slots status", js, &out); err != nil {
+		return SlotsStatus{}, err
+	}
+	return out.SlotsStatus, nil
+}
+
+// Close cancels every task (their completions finish with ErrSlotsClosed)
+// and stops the scheduler. It returns once the scheduler has returned.
+func (s *Slots) Close() error {
+	s.mu.Lock()
+	if s.closed {
+		s.mu.Unlock()
+		<-s.done
+		return nil
+	}
+	s.closed = true
+	pending := make([]*TaskCompletion, 0, len(s.tasks))
+	for _, t := range s.tasks {
+		pending = append(pending, t)
+	}
+	s.mu.Unlock()
+	close(s.stop)
+	<-s.done
+	for _, t := range pending {
+		s.cancel(t, ErrSlotsClosed)
+	}
+	return nil
+}
+
+func (s *Slots) nudge() {
+	select {
+	case s.wake <- struct{}{}:
+	default:
+	}
+}
+
+// loop is the scheduler: one update per iteration while tasks are held,
+// asleep otherwise.
+func (s *Slots) loop() {
+	defer close(s.done)
+	for {
+		select {
+		case <-s.stop:
+			return
+		case <-s.wake:
+		}
+		for {
+			select {
+			case <-s.stop:
+				return
+			default:
+			}
+			busy, err := s.update()
+			if err != nil {
+				s.fail(err)
+				break
+			}
+			if !busy {
+				break
+			}
+		}
+	}
+}
+
+// slotEvent is one entry of an update's events: a produced token (Token
+// set), a finished task (Final set) or a failed one (Error set).
+type slotEvent struct {
+	ID    int    `json:"id"`
+	Token *int32 `json:"token"`
+	textFields
+	Final *slotFinal `json:"final"`
+	Error string     `json:"error"`
+}
+
+// slotFinal is the result object of a finished task: generate's result with
+// its b64 copy of the text.
+type slotFinal struct {
+	Result
+	B64 string `json:"b64"`
+}
+
+// update runs one scheduling step and delivers its events. busy reports
+// whether any task is still held, so the caller knows to step again.
+func (s *Slots) update() (busy bool, err error) {
+	s.mu.Lock()
+	if s.closed {
+		s.mu.Unlock()
+		return false, nil
+	}
+	js, err := s.c.model.inst.e().LlamaCtxSlotsUpdate(s.c.h)
+	s.mu.Unlock()
+	if err != nil {
+		return false, err
+	}
+	var out struct {
+		envelope
+		Active int         `json:"active"`
+		Queued int         `json:"queued"`
+		Events []slotEvent `json:"events"`
+	}
+	if err := decode("slots update", js, &out); err != nil {
+		return false, err
+	}
+	for _, ev := range out.Events {
+		s.mu.Lock()
+		t := s.tasks[ev.ID]
+		s.mu.Unlock()
+		if t == nil {
+			continue // cancelled meanwhile
+		}
+		switch {
+		case ev.Final != nil:
+			res, err := finalResult(ev.Final)
+			s.finish(t, res, err)
+		case ev.Error != "":
+			s.finish(t, Result{}, fmt.Errorf("llama: slots: task %d: %s", ev.ID, ev.Error))
+		case ev.Token != nil:
+			text, err := ev.textFields.bytes("slots update")
+			if err != nil {
+				s.finish(t, Result{}, err)
+				continue
+			}
+			t.push(TaskOutput{Token: *ev.Token, Text: text})
+		}
+	}
+	return out.Active > 0 || out.Queued > 0, nil
+}
+
+// finalResult turns a final event into a Result with its text taken from the
+// lossless b64 copy.
+func finalResult(f *slotFinal) (Result, error) {
+	res := f.Result
+	text, err := textFields{Text: f.Text, B64: f.B64}.bytes("slots update")
+	if err != nil {
+		return Result{}, err
+	}
+	res.Text = text
+	return res, nil
+}
+
+// cancel drops a task in the engine and finishes its completion with err.
+func (s *Slots) cancel(t *TaskCompletion, err error) {
+	s.mu.Lock()
+	if _, held := s.tasks[t.id]; !held {
+		s.mu.Unlock()
+		return
+	}
+	js, cerr := s.c.model.inst.e().LlamaCtxSlotsCancel(s.c.h, int32(t.id))
+	s.mu.Unlock()
+	if cerr != nil {
+		// The task is no longer known to the engine: it finished in an
+		// update racing this cancel, and that update's final wins.
+		return
+	}
+	var out struct {
+		envelope
+		Queued bool       `json:"queued"`
+		Final  *slotFinal `json:"final"`
+	}
+	if derr := decode("slots cancel", js, &out); derr != nil {
+		s.finish(t, Result{}, derr)
+		return
+	}
+	res := Result{Reason: StopInterrupted, Interrupted: true}
+	if out.Final != nil {
+		if r, ferr := finalResult(out.Final); ferr == nil {
+			res = r
+		}
+	}
+	s.finish(t, res, err)
+}
+
+// fail ends every held task with err when an update itself failed.
+func (s *Slots) fail(err error) {
+	s.mu.Lock()
+	pending := make([]*TaskCompletion, 0, len(s.tasks))
+	for _, t := range s.tasks {
+		pending = append(pending, t)
+	}
+	s.mu.Unlock()
+	for _, t := range pending {
+		s.finish(t, Result{}, err)
+	}
+}
+
+// finish completes t and forgets it.
+func (s *Slots) finish(t *TaskCompletion, res Result, err error) {
+	s.mu.Lock()
+	delete(s.tasks, t.id)
+	s.mu.Unlock()
+	t.finish(res, err)
+}
+
+// TaskCompletion is a posted task: its outputs as they are produced, and its
+// result once it has finished.
+type TaskCompletion struct {
+	id int
+
+	mu      sync.Mutex
+	cond    *sync.Cond
+	outputs []TaskOutput
+	ended   bool
+	res     Result
+	err     error
+	done    chan struct{}
+}
+
+// ID is the task's id in the engine; ids start at 1 for each Context.
+func (t *TaskCompletion) ID() int { return t.id }
+
+// Outputs yields the task's outputs as they are produced and returns when
+// the task has finished. It never blocks the scheduler: outputs are kept
+// until read, so a slow reader only delays itself. Leaving the loop early
+// stops nothing; cancel the Post's ctx to stop the task.
+func (t *TaskCompletion) Outputs() iter.Seq[TaskOutput] {
+	return func(yield func(TaskOutput) bool) {
+		for i := 0; ; i++ {
+			t.mu.Lock()
+			for i >= len(t.outputs) && !t.ended {
+				t.cond.Wait()
+			}
+			if i >= len(t.outputs) {
+				t.mu.Unlock()
+				return
+			}
+			out := t.outputs[i]
+			t.mu.Unlock()
+			if !yield(out) {
+				return
+			}
+		}
+	}
+}
+
+// Wait blocks until the task has finished and returns its result: the same
+// Result a Generate of the task would return. A cancelled task returns the
+// text produced so far with StopInterrupted and the cancellation error.
+func (t *TaskCompletion) Wait() (Result, error) {
+	<-t.done
+	return t.res, t.err
+}
+
+// Result returns the finished task's result without waiting; ErrTaskRunning
+// while it has not finished.
+func (t *TaskCompletion) Result() (Result, error) {
+	select {
+	case <-t.done:
+		return t.res, t.err
+	default:
+		return Result{}, ErrTaskRunning
+	}
+}
+
+func (t *TaskCompletion) push(out TaskOutput) {
+	t.mu.Lock()
+	t.outputs = append(t.outputs, out)
+	t.mu.Unlock()
+	t.cond.Broadcast()
+}
+
+func (t *TaskCompletion) finish(res Result, err error) {
+	t.mu.Lock()
+	if t.ended {
+		t.mu.Unlock()
+		return
+	}
+	t.ended = true
+	t.res, t.err = res, err
+	t.mu.Unlock()
+	t.cond.Broadcast()
+	close(t.done)
+}

--- a/slots_test.go
+++ b/slots_test.go
@@ -295,3 +295,88 @@ func TestSlotsRefuseOversizedTask(t *testing.T) {
 		t.Fatal("Post accepted CachePrompt")
 	}
 }
+
+// A system prompt is decoded once and shared: tasks whose prompt starts with
+// it reuse its cells (NCached) and still produce exactly what Generate
+// produces for the full prompt, in both KV layouts.
+func TestSlotsSystemPrompt(t *testing.T) {
+	m := load(t)
+	const system = "You are a router. Answer with one word: the user's intent.\nUser:"
+	tails := []string{" book a table for two", " cancel my order", " what is the weather"}
+	params := llama.Params{NPredict: 8, Temperature: 0}
+	alone := make([]llama.Result, len(tails))
+	for i, tail := range tails {
+		ctx, err := m.NewContext(llama.ContextParams{NCtx: 512})
+		if err != nil {
+			t.Fatal(err)
+		}
+		res, err := ctx.Generate(system+tail, params)
+		ctx.Close()
+		if err != nil {
+			t.Fatal(err)
+		}
+		alone[i] = res
+	}
+	for _, unified := range []bool{false, true} {
+		t.Run(map[bool]string{false: "streams", true: "unified"}[unified], func(t *testing.T) {
+			ctx, err := m.NewContext(llama.ContextParams{NCtx: 2048, NSeqMax: 4, KVUnified: unified})
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer ctx.Close()
+			slots, err := ctx.Slots()
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer slots.Close()
+			if err := slots.SetSystemPrompt(system); err != nil {
+				t.Fatalf("SetSystemPrompt: %v", err)
+			}
+			st, err := slots.Status()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if st.NSlots != 3 {
+				t.Errorf("system prompt should occupy one sequence: %+v", st)
+			}
+			var cmpls []*llama.TaskCompletion
+			for _, tail := range tails {
+				c, err := slots.Post(context.Background(), llama.Task{Prompt: system + tail, Params: params})
+				if err != nil {
+					t.Fatal(err)
+				}
+				cmpls = append(cmpls, c)
+			}
+			for i, c := range cmpls {
+				res, err := c.Wait()
+				if err != nil {
+					t.Fatalf("task %d: %v", c.ID(), err)
+				}
+				if res.Text != alone[i].Text || res.NDecoded != alone[i].NDecoded {
+					t.Errorf("task %d: %q (%d), Generate alone %q (%d)", c.ID(), res.Text, res.NDecoded, alone[i].Text, alone[i].NDecoded)
+				}
+				if res.NCached < 8 || res.NCached >= res.NPrompt {
+					t.Errorf("task %d: NCached %d of %d prompt tokens: the system prompt was not reused", c.ID(), res.NCached, res.NPrompt)
+				}
+			}
+			// A prompt that does not start with the system prompt decodes in full.
+			c, err := slots.Post(context.Background(), llama.Task{Prompt: "Once upon a time", Params: params})
+			if err != nil {
+				t.Fatal(err)
+			}
+			res, err := c.Wait()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if res.NCached != 0 {
+				t.Errorf("unrelated prompt reused %d tokens", res.NCached)
+			}
+			if err := slots.SetSystemPrompt(""); err != nil {
+				t.Fatalf("clear: %v", err)
+			}
+			if st, _ := slots.Status(); st.NSlots != 4 {
+				t.Errorf("clearing the system prompt should release its sequence: %+v", st)
+			}
+		})
+	}
+}

--- a/slots_test.go
+++ b/slots_test.go
@@ -21,7 +21,9 @@ var slotPrompts = []string{
 
 func newSlotsContext(t *testing.T, m *llama.Model, nSlots uint32) (*llama.Context, *llama.Slots) {
 	t.Helper()
-	ctx, err := m.NewContext(llama.ContextParams{NCtx: 512, NSeqMax: nSlots})
+	// NCtx is split across the sequences (no KVUnified), so give each slot
+	// room for the long tasks below.
+	ctx, err := m.NewContext(llama.ContextParams{NCtx: 2048, NSeqMax: nSlots})
 	if err != nil {
 		t.Fatalf("NewContext: %v", err)
 	}
@@ -55,7 +57,24 @@ func TestSlotsMatchGenerate(t *testing.T) {
 		alone[i] = res
 	}
 
-	_, slots := newSlotsContext(t, m, 4)
+	for _, unified := range []bool{false, true} {
+		t.Run(map[bool]string{false: "streams", true: "unified"}[unified], func(t *testing.T) {
+			slotsMatchGenerate(t, m, unified, params, alone)
+		})
+	}
+}
+
+func slotsMatchGenerate(t *testing.T, m *llama.Model, unified bool, params llama.Params, alone []llama.Result) {
+	ctx, err := m.NewContext(llama.ContextParams{NCtx: 2048, NSeqMax: 4, KVUnified: unified})
+	if err != nil {
+		t.Fatalf("NewContext: %v", err)
+	}
+	defer ctx.Close()
+	slots, err := ctx.Slots()
+	if err != nil {
+		t.Fatalf("Slots: %v", err)
+	}
+	defer slots.Close()
 	cmpls := make([]*llama.TaskCompletion, len(slotPrompts))
 	for i, p := range slotPrompts {
 		c, err := slots.Post(context.Background(), llama.Task{Prompt: p, Params: params})
@@ -198,7 +217,7 @@ func TestSlotsCancelViaContext(t *testing.T) {
 // usable for single-sequence work.
 func TestSlotsClose(t *testing.T) {
 	m := load(t)
-	ctx, err := m.NewContext(llama.ContextParams{NCtx: 512, NSeqMax: 2})
+	ctx, err := m.NewContext(llama.ContextParams{NCtx: 2048, NSeqMax: 2})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/slots_test.go
+++ b/slots_test.go
@@ -1,0 +1,278 @@
+package llama_test
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	llama "github.com/goccy/go-llama"
+)
+
+var slotPrompts = []string{
+	"Once upon a time",
+	"The capital of France is",
+	"def fibonacci(n):",
+	"In the beginning",
+	"A list of three fruits:",
+	"The quick brown fox",
+}
+
+func newSlotsContext(t *testing.T, m *llama.Model, nSlots uint32) (*llama.Context, *llama.Slots) {
+	t.Helper()
+	ctx, err := m.NewContext(llama.ContextParams{NCtx: 512, NSeqMax: nSlots})
+	if err != nil {
+		t.Fatalf("NewContext: %v", err)
+	}
+	t.Cleanup(func() { ctx.Close() })
+	slots, err := ctx.Slots()
+	if err != nil {
+		t.Fatalf("Slots: %v", err)
+	}
+	t.Cleanup(func() { slots.Close() })
+	return ctx, slots
+}
+
+// Six greedy tasks on four slots — more tasks than slots, so the queue is
+// exercised — must each produce exactly what Generate produces for the same
+// prompt on a fresh context: the same text, tokens, counts and stop reason.
+func TestSlotsMatchGenerate(t *testing.T) {
+	m := load(t)
+	params := llama.Params{NPredict: 12, Temperature: 0}
+
+	alone := make([]llama.Result, len(slotPrompts))
+	for i, p := range slotPrompts {
+		ctx, err := m.NewContext(llama.ContextParams{NCtx: 512})
+		if err != nil {
+			t.Fatalf("NewContext: %v", err)
+		}
+		res, err := ctx.Generate(p, params)
+		ctx.Close()
+		if err != nil {
+			t.Fatalf("Generate(%q): %v", p, err)
+		}
+		alone[i] = res
+	}
+
+	_, slots := newSlotsContext(t, m, 4)
+	cmpls := make([]*llama.TaskCompletion, len(slotPrompts))
+	for i, p := range slotPrompts {
+		c, err := slots.Post(context.Background(), llama.Task{Prompt: p, Params: params})
+		if err != nil {
+			t.Fatalf("Post(%q): %v", p, err)
+		}
+		if c.ID() != i+1 {
+			t.Errorf("task %d posted with id %d", i+1, c.ID())
+		}
+		cmpls[i] = c
+	}
+	for i, c := range cmpls {
+		res, err := c.Wait()
+		if err != nil {
+			t.Fatalf("task %d: Wait: %v", c.ID(), err)
+		}
+		want := alone[i]
+		if res.Text != want.Text {
+			t.Errorf("task %d (%q): text %q, Generate alone %q", c.ID(), slotPrompts[i], res.Text, want.Text)
+		}
+		if len(res.Tokens) != len(want.Tokens) {
+			t.Errorf("task %d: %d tokens, Generate alone %d", c.ID(), len(res.Tokens), len(want.Tokens))
+		} else {
+			for j := range res.Tokens {
+				if res.Tokens[j] != want.Tokens[j] {
+					t.Errorf("task %d: token %d = %d, Generate alone %d", c.ID(), j, res.Tokens[j], want.Tokens[j])
+					break
+				}
+			}
+		}
+		if res.Reason != want.Reason || res.NDecoded != want.NDecoded || res.NPrompt != want.NPrompt {
+			t.Errorf("task %d: reason %q decoded %d prompt %d; Generate alone %q %d %d",
+				c.ID(), res.Reason, res.NDecoded, res.NPrompt, want.Reason, want.NDecoded, want.NPrompt)
+		}
+		// The outputs are kept for late readers and concatenate to the text.
+		var sb strings.Builder
+		n := 0
+		for out := range c.Outputs() {
+			sb.WriteString(out.Text)
+			n++
+		}
+		if sb.String() != res.Text || n != res.NDecoded {
+			t.Errorf("task %d: %d outputs concatenate to %q, result text %q (%d tokens)", c.ID(), n, sb.String(), res.Text, res.NDecoded)
+		}
+	}
+	st, err := slots.Status()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if st.NSlots != 4 || st.Active != 0 || st.Queued != 0 || st.Used != 0 {
+		t.Errorf("status after all tasks finished: %+v", st)
+	}
+}
+
+// Outputs streams while the task runs; Result refuses until it has
+// finished and then agrees with Wait.
+func TestSlotsOutputsThenResult(t *testing.T) {
+	m := load(t)
+	_, slots := newSlotsContext(t, m, 2)
+	c, err := slots.Post(context.Background(), llama.Task{Prompt: "Once upon a time", Params: llama.Params{NPredict: 8, Temperature: 0}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := c.Result(); !errors.Is(err, llama.ErrTaskRunning) {
+		t.Errorf("Result before the task finished: err = %v, want ErrTaskRunning", err)
+	}
+	var texts []string
+	for out := range c.Outputs() {
+		texts = append(texts, out.Text)
+	}
+	res, err := c.Result()
+	if err != nil {
+		t.Fatalf("Result after Outputs ended: %v", err)
+	}
+	wres, werr := c.Wait()
+	if werr != nil || wres.Text != res.Text {
+		t.Errorf("Wait after Result: %q, %v; Result %q", wres.Text, werr, res.Text)
+	}
+	if len(texts) != 8 || strings.Join(texts, "") != res.Text {
+		t.Errorf("%d outputs %q vs result %q", len(texts), strings.Join(texts, ""), res.Text)
+	}
+}
+
+// Cancelling the Post's ctx drops the task: its slot is released, and the
+// completion carries the text so far, StopInterrupted and ctx.Err().
+func TestSlotsCancelViaContext(t *testing.T) {
+	m := load(t)
+	_, slots := newSlotsContext(t, m, 2)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	c, err := slots.Post(ctx, llama.Task{Prompt: "Once upon a time", Params: llama.Params{NPredict: 200, Temperature: 0}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	n := 0
+	for out := range c.Outputs() {
+		n++
+		if out.Text == "" && out.Token == 0 {
+			t.Errorf("empty output")
+		}
+		if n == 3 {
+			cancel()
+		}
+	}
+	res, err := c.Wait()
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("Wait after cancel: err = %v, want context.Canceled", err)
+	}
+	if res.Reason != llama.StopInterrupted || !res.Interrupted || res.NDecoded < 3 || res.NDecoded > 200 {
+		t.Errorf("cancelled result: %+v", res)
+	}
+	st, err := slots.Status()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if st.Active != 0 || st.Used != 0 {
+		t.Errorf("status after cancel: %+v", st)
+	}
+
+	// A deadline works the same way, on a task that never got a slot too.
+	dctx, dcancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer dcancel()
+	long := llama.Task{Prompt: "Once upon a time", Params: llama.Params{NPredict: 400, Temperature: 0}}
+	first, err := slots.Post(dctx, long)
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := slots.Post(dctx, long)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, c := range []*llama.TaskCompletion{first, second} {
+		if _, err := c.Wait(); !errors.Is(err, context.DeadlineExceeded) {
+			t.Errorf("task %d: err = %v, want DeadlineExceeded", c.ID(), err)
+		}
+	}
+}
+
+// Close cancels every task and refuses further posts; the context stays
+// usable for single-sequence work.
+func TestSlotsClose(t *testing.T) {
+	m := load(t)
+	ctx, err := m.NewContext(llama.ContextParams{NCtx: 512, NSeqMax: 2})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ctx.Close()
+	slots, err := ctx.Slots()
+	if err != nil {
+		t.Fatal(err)
+	}
+	long := llama.Task{Prompt: "Once upon a time", Params: llama.Params{NPredict: 400, Temperature: 0}}
+	var cmpls []*llama.TaskCompletion
+	for i := 0; i < 3; i++ {
+		c, err := slots.Post(context.Background(), long)
+		if err != nil {
+			t.Fatal(err)
+		}
+		cmpls = append(cmpls, c)
+	}
+	if err := slots.Close(); err != nil {
+		t.Fatal(err)
+	}
+	for _, c := range cmpls {
+		if _, err := c.Wait(); !errors.Is(err, llama.ErrSlotsClosed) {
+			t.Errorf("task %d after Close: err = %v, want ErrSlotsClosed", c.ID(), err)
+		}
+	}
+	if _, err := slots.Post(context.Background(), long); !errors.Is(err, llama.ErrSlotsClosed) {
+		t.Errorf("Post after Close: err = %v, want ErrSlotsClosed", err)
+	}
+	if err := slots.Close(); err != nil {
+		t.Errorf("second Close: %v", err)
+	}
+	if _, err := ctx.Generate("Once upon a time", llama.Params{NPredict: 4, Temperature: 0}); err != nil {
+		t.Errorf("Generate after Slots.Close: %v", err)
+	}
+}
+
+// While a task is held, the context's single-sequence methods refuse; once
+// the slots are idle they work again.
+func TestSlotsRefuseSingleSequenceCalls(t *testing.T) {
+	m := load(t)
+	ctx, slots := newSlotsContext(t, m, 2)
+	pctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	c, err := slots.Post(pctx, llama.Task{Prompt: "Once upon a time", Params: llama.Params{NPredict: 400, Temperature: 0}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for range c.Outputs() {
+		break // one output: the task holds a slot
+	}
+	if _, err := ctx.Generate("The", llama.Params{NPredict: 2, Temperature: 0}); err == nil {
+		t.Error("Generate ran while a task held a slot")
+	}
+	if _, err := ctx.Score("The end"); err == nil {
+		t.Error("Score ran while a task held a slot")
+	}
+	cancel()
+	if _, err := c.Wait(); !errors.Is(err, context.Canceled) {
+		t.Fatalf("Wait: %v", err)
+	}
+	if _, err := ctx.Generate("The", llama.Params{NPredict: 2, Temperature: 0}); err != nil {
+		t.Errorf("Generate after the task was cancelled: %v", err)
+	}
+}
+
+// A task that can never fit the context is refused at Post.
+func TestSlotsRefuseOversizedTask(t *testing.T) {
+	m := load(t)
+	_, slots := newSlotsContext(t, m, 2)
+	_, err := slots.Post(context.Background(), llama.Task{Prompt: "Once upon a time", Params: llama.Params{NPredict: 100000, Temperature: 0}})
+	if err == nil {
+		t.Fatal("Post accepted a task larger than the context")
+	}
+	if _, err := slots.Post(context.Background(), llama.Task{Prompt: "x", Params: llama.Params{CachePrompt: true}}); err == nil {
+		t.Fatal("Post accepted CachePrompt")
+	}
+}

--- a/slots_test.go
+++ b/slots_test.go
@@ -359,8 +359,23 @@ func TestSlotsSystemPrompt(t *testing.T) {
 					t.Errorf("task %d: NCached %d of %d prompt tokens: the system prompt was not reused", c.ID(), res.NCached, res.NPrompt)
 				}
 			}
-			// A prompt that does not start with the system prompt decodes in full.
-			c, err := slots.Post(context.Background(), llama.Task{Prompt: "Once upon a time", Params: params})
+			// A prompt that does not start with the system prompt reuses only
+			// what its tokens share with it (a BOS token, on vocabularies that
+			// add one).
+			const unrelated = "Once upon a time"
+			sysToks, err := m.Tokenize(system, true, true)
+			if err != nil {
+				t.Fatal(err)
+			}
+			unrelToks, err := m.Tokenize(unrelated, true, true)
+			if err != nil {
+				t.Fatal(err)
+			}
+			shared := 0
+			for shared < len(sysToks) && shared < len(unrelToks)-1 && sysToks[shared] == unrelToks[shared] {
+				shared++
+			}
+			c, err := slots.Post(context.Background(), llama.Task{Prompt: unrelated, Params: params})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -368,8 +383,8 @@ func TestSlotsSystemPrompt(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			if res.NCached != 0 {
-				t.Errorf("unrelated prompt reused %d tokens", res.NCached)
+			if res.NCached != shared {
+				t.Errorf("unrelated prompt reused %d tokens, its tokens share %d with the system prompt", res.NCached, shared)
 			}
 			if err := slots.SetSystemPrompt(""); err != nil {
 				t.Fatalf("clear: %v", err)

--- a/text_fields_test.go
+++ b/text_fields_test.go
@@ -1,0 +1,55 @@
+package llama
+
+import (
+	"strings"
+	"testing"
+)
+
+// A bridge result carries model-produced bytes twice: as a JSON string and as
+// b64. The b64 copy is authoritative because a JSON string cannot carry a
+// partial UTF-8 sequence losslessly; text alone must still work for bridges
+// that predate the b64 field.
+func TestTextFieldsBytes(t *testing.T) {
+	// 0xE7 0xAB is the first two bytes of a three-byte character: the kind of
+	// piece a byte-level tokenizer produces when a character spans tokens.
+	partial := "\xe7\xab"
+	cases := []struct {
+		name    string
+		in      textFields
+		want    string
+		wantErr string
+	}{
+		{name: "text only", in: textFields{Text: "hello"}, want: "hello"},
+		{name: "b64 wins", in: textFields{Text: "\ufffd\ufffd", B64: "56s="}, want: partial},
+		{name: "b64 empty text", in: textFields{Text: "", B64: "aGk="}, want: "hi"},
+		{name: "bad b64", in: textFields{Text: "x", B64: "!!"}, wantErr: "bad b64 payload"},
+	}
+	for _, tc := range cases {
+		got, err := tc.in.bytes("test")
+		if tc.wantErr != "" {
+			if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+				t.Errorf("%s: err = %v, want %q", tc.name, err, tc.wantErr)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("%s: %v", tc.name, err)
+			continue
+		}
+		if got != tc.want {
+			t.Errorf("%s: got %q, want %q", tc.name, got, tc.want)
+		}
+	}
+}
+
+// decodeText accepts a result with and without the b64 field.
+func TestDecodeTextB64(t *testing.T) {
+	got, err := decodeText("t", `{"ok":true,"text":"\ufffd","b64":"5w=="}`)
+	if err != nil || got != "\xe7" {
+		t.Fatalf("with b64: got %q, %v; want the raw byte 0xE7", got, err)
+	}
+	got, err = decodeText("t", `{"ok":true,"text":"plain"}`)
+	if err != nil || got != "plain" {
+		t.Fatalf("without b64: got %q, %v", got, err)
+	}
+}

--- a/types.go
+++ b/types.go
@@ -195,6 +195,13 @@ type genRequest struct {
 
 // wire converts Params into the bridge's parameter object, translating the two
 // places where Go's zero value and llama.cpp's "off" value disagree.
+// taskRequest is the task JSON of llama_ctx_slots_post: a generate request
+// plus the prompt, flat.
+type taskRequest struct {
+	Prompt string `json:"prompt"`
+	genRequest
+}
+
 func (p Params) wire() genRequest {
 	req := genRequest{
 		NPredict:         p.NPredict,


### PR DESCRIPTION
## What

Adopts the llamawasm2go v0.4.0 bundle (llama-wasm v0.4.0: goccy/llama-wasm#32, #29, #28, #30, #31) and adds the Go API on top of it.

**Slots — continuous batching over one Context**, in llama.cpp's server vocabulary:
- `Task{Prompt, Params}` is a plain value; `Slots.Post(ctx, task) (*TaskCompletion, error)` queues it (FIFO, admission by free slot and free cells); cancellation is the Post's `context.Context`.
- `TaskCompletion.Outputs() iter.Seq[TaskOutput]` streams each produced token (pull-based, never stalls the batch), `Wait() (Result, error)` blocks for the result, `Result()` returns it once finished (`ErrTaskRunning` before).
- `Slots.SetSystemPrompt(text)`: an instruction decoded once and shared by every task that starts with it (`Result.NCached` reports the reuse). `Status()`, `Close()`.
- `ContextParams.KVUnified` follows llama.cpp's `kv_unified` (default off: per-sequence streams of `NCtx / NSeqMax` cells; on: one shared buffer, what `ScoreChoices` with `NSeqMax > 1` relies on — its test sets it).

**Lossless text**: `Result.Text`, `Detokenize` and `TokenToPiece` take the bridge's `b64` copy, so a partial UTF-8 sequence no longer differs between `Stream`'s pieces and the returned text (`TestStreamDeliversTextWhileGenerating` on byte-salad output found it).

The bridge grew five exports, so the service-0 method ids after `ScoreChoices` shift by five; `repackF16Table` moves to 8795968.

## Tests

New: `TestSlotsMatchGenerate` (six greedy tasks on four slots, both KV layouts, identical text/tokens/counts/reason to `Generate`), `TestSlotsOutputsThenResult`, `TestSlotsCancelViaContext`, `TestSlotsClose`, `TestSlotsRefuseSingleSequenceCalls`, `TestSlotsRefuseOversizedTask`, `TestSlotsSystemPrompt` (both layouts; reuse reproduces `Generate` of the full prompt), `TestDetokenizeKeepsPartialUTF8`, decoder unit tests. Locally (arm64 native, tagged module): default-model suite, q8_0 suite and `internal` all pass; vet clean on arm64, amd64 v2 and amd64 v1.

## Measured (M5, 8 threads, 0.5B Q8_0, 100 requests at once, 45-token shared instruction + short user part, 16 tokens each)

| serving | first token p50 / p99 | completed p50 / p99 | aggregate |
|---|---|---|---|
| 8 forked instances × 1 thread (best pre-existing) | 3.9 s / 7.6 s | 4.3 s / 7.8 s | 205 tok/s |
| slots 8 | 2.6 s / 4.9 s | 2.8 s / 5.0 s | 322 tok/s |
| slots 32 + system prompt | 0.85 s / 2.2 s | 1.5 s / 2.4 s | 655 tok/s |

Batching itself is exact (tasks sharing a batch reproduce `Generate`); a long prompt chunked differently across steps can land on the other side of a near-tie, as `Generate` itself does with a different `NBatch` — documented in the README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
